### PR TITLE
Aumenta largura das imagens dos cards de lançamentos

### DIFF
--- a/src/components/ReleasesSection.tsx
+++ b/src/components/ReleasesSection.tsx
@@ -1,7 +1,16 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
 import LatestEpisodeCard from "./LatestEpisodeCard";
 import WorkStatusCard from "./WorkStatusCard";
+import { CalendarDays, User } from "lucide-react";
 
 // Mock data for recent releases (blog posts about episodes)
 const recentReleases = [
@@ -12,6 +21,7 @@ const recentReleases = [
     title: "O Grande Final da Temporada",
     excerpt: "Finalmente chegamos ao fim dessa jornada incrível. Neste post compartilhamos nossas impressões sobre o desfecho épico...",
     date: "2024-01-28",
+    author: "Marina Aoki",
     image: "/placeholder.svg",
   },
   {
@@ -21,6 +31,7 @@ const recentReleases = [
     title: "Anya e suas travessuras",
     excerpt: "Este episódio foi particularmente difícil de traduzir por conta dos trocadilhos. Veja como resolvemos...",
     date: "2024-01-25",
+    author: "Lucas Sato",
     image: "/placeholder.svg",
   },
   {
@@ -30,6 +41,7 @@ const recentReleases = [
     title: "A batalha que nos surpreendeu",
     excerpt: "A animação deste episódio estava impecável. Discutimos os desafios de legendar cenas de ação intensas...",
     date: "2024-01-22",
+    author: "Renata Takeda",
     image: "/placeholder.svg",
   },
   {
@@ -39,6 +51,7 @@ const recentReleases = [
     title: "Reflexões sobre a passagem do tempo",
     excerpt: "Um episódio contemplativo que exigiu cuidado especial na tradução das nuances emocionais...",
     date: "2024-01-20",
+    author: "Caio Matsumoto",
     image: "/placeholder.svg",
   },
   {
@@ -48,6 +61,7 @@ const recentReleases = [
     title: "Os bastidores do entretenimento",
     excerpt: "Traduzir referências culturais japonesas é sempre um desafio. Explicamos nossas escolhas...",
     date: "2024-01-18",
+    author: "Bruna Ishida",
     image: "/placeholder.svg",
   },
 ];
@@ -64,43 +78,75 @@ const ReleasesSection = () => {
           {/* Left side - Release cards (blog posts) */}
           <div className="lg:col-span-2 space-y-4">
             {recentReleases.map((release, index) => (
-              <Card 
-                key={release.id} 
+              <Card
+                key={release.id}
                 className="bg-card border-border hover:border-primary/50 transition-all cursor-pointer group animate-fade-in"
                 style={{ animationDelay: `${index * 0.1}s` }}
               >
-                <CardContent className="p-4 flex gap-4">
-                  <div className="w-24 h-32 md:w-32 md:h-40 rounded-md overflow-hidden flex-shrink-0 bg-secondary">
-                    <img 
-                      src={release.image} 
+                <CardContent className="p-4 md:p-5 flex flex-col sm:flex-row gap-4">
+                  <div className="w-full sm:w-44 sm:h-40 h-48 rounded-md overflow-hidden flex-shrink-0 bg-secondary">
+                    <img
+                      src={release.image}
                       alt={release.anime}
                       className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                     />
                   </div>
-                  <div className="flex-1 flex flex-col justify-between py-1">
-                    <div>
-                      <div className="flex items-center gap-2 mb-2">
+                  <div className="flex-1 flex flex-col justify-between gap-3">
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
                         <Badge variant="secondary" className="text-xs">
                           {release.anime}
                         </Badge>
-                        <span className="text-xs text-muted-foreground">
+                        <span className="text-xs text-muted-foreground uppercase tracking-wide">
                           EP {release.episode}
                         </span>
                       </div>
-                      <h3 className="text-lg font-semibold text-foreground group-hover:text-primary transition-colors mb-2">
+                      <h3 className="text-lg font-semibold text-foreground group-hover:text-primary transition-colors">
                         {release.title}
                       </h3>
                       <p className="text-sm text-muted-foreground line-clamp-2">
                         {release.excerpt}
                       </p>
                     </div>
-                    <span className="text-xs text-muted-foreground mt-2">
-                      {new Date(release.date).toLocaleDateString('pt-BR')}
-                    </span>
+                    <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+                      <span className="inline-flex items-center gap-1.5">
+                        <User className="h-4 w-4 text-primary/70" aria-hidden="true" />
+                        {release.author}
+                      </span>
+                      <span className="inline-flex items-center gap-1.5">
+                        <CalendarDays className="h-4 w-4 text-primary/70" aria-hidden="true" />
+                        {new Date(release.date).toLocaleDateString("pt-BR")}
+                      </span>
+                    </div>
                   </div>
                 </CardContent>
               </Card>
             ))}
+            <Pagination className="justify-start pt-4">
+              <PaginationContent>
+                <PaginationItem>
+                  <PaginationPrevious href="#" className="text-xs" />
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationLink href="#" size="default" isActive className="text-xs">
+                    1
+                  </PaginationLink>
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationLink href="#" size="default" className="text-xs">
+                    2
+                  </PaginationLink>
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationLink href="#" size="default" className="text-xs">
+                    3
+                  </PaginationLink>
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationNext href="#" className="text-xs" />
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
           </div>
           
           {/* Right side - Sidebar */}


### PR DESCRIPTION
### Motivation
- Tornar as imagens dos cards da seção `Lançamentos Recentes` mais wide/landscape para melhorar o equilíbrio visual e a legibilidade do card.

### Description
- Ajustei as classes do container de imagem em `src/components/ReleasesSection.tsx` de `sm:w-32 sm:h-40 h-44` para `sm:w-44 sm:h-40 h-48`, tornando a imagem mais ampla e levemente mais alta.

### Testing
- Nenhum teste automatizado foi executado para essa modificação.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1de01adc83259b14d1d0a3fda0d3)