### PR TITLE
Refina espaçamento e alinhamento dos cards de Atualizações Recentes

### DIFF
--- a/src/components/LatestEpisodeCard.tsx
+++ b/src/components/LatestEpisodeCard.tsx
@@ -1,50 +1,109 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Play } from "lucide-react";
+import { Clock, Sparkles } from "lucide-react";
 import { Link } from "react-router-dom";
 
 const LatestEpisodeCard = () => {
-  const latestEpisode = {
-    anime: "Fate/Kaleid Liner Prisma Illya",
-    episode: 12,
-    season: 1,
-    image: "/placeholder.svg",
-    slug: "fate-kaleid-liner-prisma-illya",
-  };
+  const recentUpdates = [
+    {
+      id: 1,
+      anime: "Gabriel Dropout",
+      episode: 7,
+      season: 1,
+      reason: "Correção de timing e revisão de script",
+      updatedAt: "2024-01-29",
+      image: "/placeholder.svg",
+      slug: "gabriel-dropout",
+    },
+    {
+      id: 2,
+      anime: "Jujutsu Kaisen",
+      episode: 15,
+      season: 2,
+      reason: "Ajuste de karaoke e notas de tradução",
+      updatedAt: "2024-01-28",
+      image: "/placeholder.svg",
+      slug: "jujutsu-kaisen",
+    },
+    {
+      id: 3,
+      anime: "Frieren",
+      episode: 20,
+      season: 1,
+      reason: "Revisão de contexto cultural e tips",
+      updatedAt: "2024-01-27",
+      image: "/placeholder.svg",
+      slug: "frieren",
+    },
+    {
+      id: 4,
+      anime: "Spy x Family",
+      episode: 8,
+      season: 2,
+      reason: "Correções finas de legendagem",
+      updatedAt: "2024-01-26",
+      image: "/placeholder.svg",
+      slug: "spy-x-family",
+    },
+    {
+      id: 5,
+      anime: "Oshi no Ko",
+      episode: 6,
+      season: 1,
+      reason: "Sincronização com novo encode",
+      updatedAt: "2024-01-24",
+      image: "/placeholder.svg",
+      slug: "oshi-no-ko",
+    },
+  ];
 
   return (
     <Card className="bg-card border-border overflow-hidden">
       <CardHeader className="pb-3">
         <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
-          <Play className="w-4 h-4 text-primary" />
-          Último Episódio
+          <Sparkles className="w-4 h-4 text-primary" />
+          Atualizações Recentes
         </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Episódios que receberam ajustes ou revisões recentemente.
+        </p>
       </CardHeader>
-      <CardContent className="p-0">
-        <Link 
-          to={`/anime/${latestEpisode.slug}`}
-          className="block group"
-        >
-          <div className="relative aspect-video overflow-hidden">
-            <img 
-              src={latestEpisode.image}
-              alt={latestEpisode.anime}
-              className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-background/90 to-transparent" />
-            <div className="absolute bottom-0 left-0 right-0 p-4">
-              <Badge className="mb-2 bg-primary text-primary-foreground">
-                EP {latestEpisode.episode}
-              </Badge>
-              <h4 className="text-sm font-semibold text-foreground line-clamp-2 group-hover:text-primary transition-colors">
-                {latestEpisode.anime}
+      <CardContent className="space-y-3">
+        {recentUpdates.map((update) => (
+          <Link
+            key={update.id}
+            to={`/anime/${update.slug}`}
+            className="group flex items-start gap-4 rounded-xl border border-border/60 bg-background/40 p-4 transition hover:border-primary/40 hover:bg-primary/5"
+          >
+            <div className="w-20 flex-shrink-0 overflow-hidden rounded-lg bg-secondary aspect-[2/3]">
+              <img
+                src={update.image}
+                alt={update.anime}
+                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                  EP {update.episode}
+                </Badge>
+                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Temporada {update.season}
+                </span>
+              </div>
+              <h4 className="truncate text-sm font-semibold text-foreground transition-colors group-hover:text-primary">
+                {update.anime}
               </h4>
-              <span className="text-xs text-muted-foreground">
-                Temporada {latestEpisode.season}
+              <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
+                {update.reason}
+              </p>
+              <span className="inline-flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                <Clock className="h-3 w-3 text-primary/70" aria-hidden="true" />
+                {new Date(update.updatedAt).toLocaleDateString("pt-BR")}
               </span>
             </div>
-          </div>
-        </Link>
+          </Link>
+        ))}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
### Motivation
- Tornar o layout dos cards de atualizações mais agradável refinando espaçamento, padding e alinhamento entre imagem e texto.
- Consolidar o componente para exibir múltiplas atualizações em mini-cards com miniaturas em proporção póster (2:3) e metadados visíveis.

### Description
- Substitui o objeto `latestEpisode` por um array `recentUpdates` e passa a renderizar múltiplos mini-cards com `recentUpdates.map(...)`.
- Ajusta o wrapper do link para `className="group flex items-start gap-4 rounded-xl ... p-4"` aumentando `gap` e `padding`, e altera o wrapper da imagem para `rounded-lg` com `aspect-[2/3]` para proporção de pôster.
- Refina tipografia e espaçamento interno: `gap-2` no conteúdo, `uppercase tracking-wide` no `Badge`, `leading-relaxed` no parágrafo de motivo e `gap-1.5` no bloco de data com o ícone `Clock`.
- Atualiza cabeçalho para `Atualizações Recentes` com o ícone `Sparkles` e adiciona uma breve descrição contextual abaixo do título.

### Testing
- Levantei o servidor de desenvolvimento com `npm run dev -- --host 0.0.0.0 --port 4173` e o Vite retornou pronto com sucesso e endereços acessíveis; this step succeeded.
- Tentei rodar um script Playwright para gerar um screenshot (`artifacts/atualizacoes-recentes-espacamento.png`), porém o Chromium travou e o Playwright encerrou com `TargetClosedError`, então a captura não foi gerada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2eaad1c88325b8df372596e63684)