### PR TITLE
Reduz lista de atualizações para três cards e refatora LatestEpisodeCard

### DIFF
--- a/src/components/LatestEpisodeCard.tsx
+++ b/src/components/LatestEpisodeCard.tsx
@@ -1,50 +1,92 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Play } from "lucide-react";
+import { Clock, Sparkles } from "lucide-react";
 import { Link } from "react-router-dom";
 
 const LatestEpisodeCard = () => {
-  const latestEpisode = {
-    anime: "Fate/Kaleid Liner Prisma Illya",
-    episode: 12,
-    season: 1,
-    image: "/placeholder.svg",
-    slug: "fate-kaleid-liner-prisma-illya",
-  };
+  const recentUpdates = [
+    {
+      id: 1,
+      anime: "Gabriel Dropout",
+      episode: 7,
+      season: 1,
+      kind: "Atualização",
+      reason: "Correção de timing e revisão de script",
+      updatedAt: "2024-01-29",
+      image: "/placeholder.svg",
+      slug: "gabriel-dropout",
+    },
+    {
+      id: 2,
+      anime: "Jujutsu Kaisen",
+      episode: 15,
+      season: 2,
+      kind: "Atualização",
+      reason: "Ajuste de karaoke e notas de tradução",
+      updatedAt: "2024-01-28",
+      image: "/placeholder.svg",
+      slug: "jujutsu-kaisen",
+    },
+    {
+      id: 3,
+      anime: "Fate/Kaleid Liner Prisma Illya",
+      episode: 12,
+      season: 1,
+      kind: "Lançamento",
+      reason: "Episódio novo disponível na plataforma",
+      updatedAt: "2024-01-28",
+      image: "/placeholder.svg",
+      slug: "fate-kaleid-liner-prisma-illya",
+    },
+  ];
 
   return (
     <Card className="bg-card border-border overflow-hidden">
       <CardHeader className="pb-3">
         <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
-          <Play className="w-4 h-4 text-primary" />
-          Último Episódio
+          <Sparkles className="w-4 h-4 text-primary" />
+          Atualizações Recentes
         </CardTitle>
       </CardHeader>
-      <CardContent className="p-0">
-        <Link 
-          to={`/anime/${latestEpisode.slug}`}
-          className="block group"
-        >
-          <div className="relative aspect-video overflow-hidden">
-            <img 
-              src={latestEpisode.image}
-              alt={latestEpisode.anime}
-              className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-background/90 to-transparent" />
-            <div className="absolute bottom-0 left-0 right-0 p-4">
-              <Badge className="mb-2 bg-primary text-primary-foreground">
-                EP {latestEpisode.episode}
-              </Badge>
-              <h4 className="text-sm font-semibold text-foreground line-clamp-2 group-hover:text-primary transition-colors">
-                {latestEpisode.anime}
+      <CardContent className="space-y-3">
+        {recentUpdates.map((update) => (
+          <Link
+            key={update.id}
+            to={`/anime/${update.slug}`}
+            className="group flex items-start gap-4 rounded-xl border border-border/60 bg-background/40 p-4 transition hover:border-primary/40 hover:bg-primary/5"
+          >
+            <div className="w-24 flex-shrink-0 overflow-hidden rounded-lg bg-secondary aspect-[2/3]">
+              <img
+                src={update.image}
+                alt={update.anime}
+                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                  EP {update.episode}
+                </Badge>
+                <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                  {update.kind}
+                </Badge>
+                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Temporada {update.season}
+                </span>
+              </div>
+              <h4 className="truncate text-sm font-semibold text-foreground transition-colors group-hover:text-primary">
+                {update.anime}
               </h4>
-              <span className="text-xs text-muted-foreground">
-                Temporada {latestEpisode.season}
+              <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
+                {update.reason}
+              </p>
+              <span className="inline-flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                <Clock className="h-3 w-3 text-primary/70" aria-hidden="true" />
+                {new Date(update.updatedAt).toLocaleDateString("pt-BR")}
               </span>
             </div>
-          </div>
-        </Link>
+          </Link>
+        ))}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
### Motivation
- Tornar a lista de atualizações mais concisa ao exibir somente três itens na seção de "Atualizações Recentes" por solicitação de design.
- Unificar e melhorar a exibição de lançamentos e atualizações em um único componente com informações mais ricas (tipo, motivo e data).

### Description
- Substitui o objeto `latestEpisode` por um array `recentUpdates` e passa a renderizar múltiplos itens com `recentUpdates.map(...)` no arquivo `src/components/LatestEpisodeCard.tsx`.
- Limita o array a três entradas de exemplo e ajusta o layout do card para `group flex items-start gap-4 rounded-xl ... p-4` com miniaturas ampliadas (`w-24` e `aspect-[2/3]`).
- Atualiza o cabeçalho para `Atualizações Recentes` com o ícone `Sparkles`, adiciona um `Badge` `outline` para exibir `kind`, e inclui o ícone `Clock` para mostrar `updatedAt` formatado em `pt-BR`.
- Remove a exibição de um único card em formato banner e adiciona tipografia, espaçamento e estados de hover refinados para cada item da lista.

### Testing
- Levantei o servidor de desenvolvimento com `npm run dev -- --host 0.0.0.0 --port 4173` e o Vite inicializou com sucesso e mostrou endereços acessíveis.
- Gere uma captura de tela automatizada com Playwright e produzi o arquivo `artifacts/atualizacoes-recentes-tres-cards.png`, indicando renderização correta dos três cards.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2eaad1c88325b8df372596e63684)