### PR TITLE
Corrige formatação de data e ajusta layout de 'Atualizações Recentes' e 'Em Progresso'

### DIFF
--- a/src/components/LatestEpisodeCard.tsx
+++ b/src/components/LatestEpisodeCard.tsx
@@ -1,50 +1,102 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Play } from "lucide-react";
+import { Clock, Sparkles } from "lucide-react";
 import { Link } from "react-router-dom";
 
+const formatLocalDate = (dateString: string) => {
+  const [year, month, day] = dateString.split("-").map(Number);
+
+  if (!year || !month || !day) {
+    return dateString;
+  }
+
+  return new Date(year, month - 1, day).toLocaleDateString("pt-BR");
+};
+
 const LatestEpisodeCard = () => {
-  const latestEpisode = {
-    anime: "Fate/Kaleid Liner Prisma Illya",
-    episode: 12,
-    season: 1,
-    image: "/placeholder.svg",
-    slug: "fate-kaleid-liner-prisma-illya",
-  };
+  const recentUpdates = [
+    {
+      id: 1,
+      anime: "Gabriel Dropout",
+      episode: 7,
+      season: 1,
+      kind: "Atualização",
+      reason: "Correção de timing e revisão de script",
+      updatedAt: "2024-01-29",
+      image: "/placeholder.svg",
+      slug: "gabriel-dropout",
+    },
+    {
+      id: 2,
+      anime: "Jujutsu Kaisen",
+      episode: 15,
+      season: 2,
+      kind: "Atualização",
+      reason: "Ajuste de karaoke e notas de tradução",
+      updatedAt: "2024-01-28",
+      image: "/placeholder.svg",
+      slug: "jujutsu-kaisen",
+    },
+    {
+      id: 3,
+      anime: "Fate/Kaleid Liner Prisma Illya",
+      episode: 12,
+      season: 1,
+      kind: "Lançamento",
+      reason: "Episódio novo disponível na plataforma",
+      updatedAt: "2024-01-28",
+      image: "/placeholder.svg",
+      slug: "fate-kaleid-liner-prisma-illya",
+    },
+  ];
 
   return (
     <Card className="bg-card border-border overflow-hidden">
-      <CardHeader className="pb-3">
+      <CardHeader className="px-4 pb-3 pt-4">
         <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
-          <Play className="w-4 h-4 text-primary" />
-          Último Episódio
+          <Sparkles className="w-4 h-4 text-primary" />
+          Atualizações Recentes
         </CardTitle>
       </CardHeader>
-      <CardContent className="p-0">
-        <Link 
-          to={`/anime/${latestEpisode.slug}`}
-          className="block group"
-        >
-          <div className="relative aspect-video overflow-hidden">
-            <img 
-              src={latestEpisode.image}
-              alt={latestEpisode.anime}
-              className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-background/90 to-transparent" />
-            <div className="absolute bottom-0 left-0 right-0 p-4">
-              <Badge className="mb-2 bg-primary text-primary-foreground">
-                EP {latestEpisode.episode}
-              </Badge>
-              <h4 className="text-sm font-semibold text-foreground line-clamp-2 group-hover:text-primary transition-colors">
-                {latestEpisode.anime}
+      <CardContent className="space-y-3 px-4 pb-4 pt-0">
+        {recentUpdates.map((update) => (
+          <Link
+            key={update.id}
+            to={`/anime/${update.slug}`}
+            className="group flex items-start gap-4 rounded-xl border border-border/60 bg-background/40 p-4 transition hover:border-primary/40 hover:bg-primary/5"
+          >
+            <div className="w-24 flex-shrink-0 overflow-hidden rounded-lg bg-secondary aspect-[2/3]">
+              <img
+                src={update.image}
+                alt={update.anime}
+                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                  EP {update.episode}
+                </Badge>
+                <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                  {update.kind}
+                </Badge>
+                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Temporada {update.season}
+                </span>
+              </div>
+              <h4 className="truncate text-sm font-semibold text-foreground transition-colors group-hover:text-primary">
+                {update.anime}
               </h4>
-              <span className="text-xs text-muted-foreground">
-                Temporada {latestEpisode.season}
+              <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
+                {update.reason}
+              </p>
+              <span className="inline-flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                <Clock className="h-3 w-3 text-primary/70" aria-hidden="true" />
+                {formatLocalDate(update.updatedAt)}
               </span>
             </div>
-          </div>
-        </Link>
+          </Link>
+        ))}
       </CardContent>
     </Card>
   );

--- a/src/components/WorkStatusCard.tsx
+++ b/src/components/WorkStatusCard.tsx
@@ -50,13 +50,13 @@ const workItems: WorkItem[] = [
 const WorkStatusCard = () => {
   return (
     <Card className="bg-card border-border">
-      <CardHeader className="pb-3">
+      <CardHeader className="px-4 pb-3 pt-4">
         <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
           <Clock className="w-4 h-4 text-primary" />
           Em Progresso
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-3">
+      <CardContent className="space-y-3 px-4 pb-4 pt-0">
         {workItems.map((item) => {
           const config = statusConfig[item.status];
           return (


### PR DESCRIPTION
### Motivation
- Converter a seção "Último Episódio" para uma lista de "Atualizações Recentes" que mostre tanto lançamentos quanto correções mais recentes e exiba múltiplos cards.
- Alinhar espaçamento e padding do card `WorkStatusCard` ao novo padrão visual aplicado em `LatestEpisodeCard` para consistência do dashboard.
- Evitar erro de exibição da data causado por parsing UTC de strings `YYYY-MM-DD` em fusos horários negativos.

### Description
- Substitui o card único por uma lista de updates em `src/components/LatestEpisodeCard.tsx`, renomeando o título para "Atualizações Recentes" e introduzindo múltiplos cards com miniaturas em proporção de pôster (aspect 2:3), badges e razão da atualização. 
- Remove a descrição de cabeçalho informativa e ajusta largura/espacamento das miniaturas para ficar menos estreito conforme solicitado. 
- Adiciona a função `formatLocalDate(dateString)` que interpreta strings `YYYY-MM-DD` como data local (`new Date(year, month-1, day)`) antes de chamar `toLocaleDateString("pt-BR")` para evitar off-by-one por timezone. 
- Alinha `CardHeader` e `CardContent` em `src/components/WorkStatusCard.tsx` para `px-4 pb-3 pt-4` e `space-y-3 px-4 pb-4 pt-0` respectivamente, mantendo o comportamento dos itens de trabalho.

### Testing
- Iniciei o servidor de desenvolvimento com `npm run dev -- --host 0.0.0.0 --port 4173` na rodada anterior e o Vite subiu corretamente, indicando que a aplicação de dev iniciou com sucesso. 
- Tentativa de captura de tela automatizada com Playwright falhou por erro do Chromium (`TargetClosedError`/segfault) e não gerou artefatos visuais. 
- O ajuste de formatação de data foi aplicado e commitado, mas não houve execução adicional de testes automatizados nesta rodada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2eaad1c88325b8df372596e63684)