### PR TITLE
Support anime/manga stages and per-item progress bars in WorkStatusCard

### DIFF
--- a/src/components/WorkStatusCard.tsx
+++ b/src/components/WorkStatusCard.tsx
@@ -1,53 +1,114 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Clock, CheckCircle, Edit3, Eye, Mic } from "lucide-react";
+import { Progress } from "@/components/ui/progress";
+import { Clock } from "lucide-react";
 
-type WorkStatus = "traducao" | "revisao" | "encode" | "qc" | "finalizado";
+type WorkKind = "anime" | "manga";
 
 interface WorkItem {
   id: number;
-  anime: string;
-  episode: number;
-  status: WorkStatus;
+  title: string;
+  entry: string;
+  kind: WorkKind;
+  currentStage: string;
+  completedStages: string[];
 }
 
-const statusConfig: Record<WorkStatus, { label: string; color: string; icon: React.ReactNode }> = {
-  traducao: { 
-    label: "Tradução", 
-    color: "bg-blue-500/20 text-blue-400 border-blue-500/30",
-    icon: <Edit3 className="w-3 h-3" />
-  },
-  revisao: { 
-    label: "Revisão", 
-    color: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
-    icon: <Eye className="w-3 h-3" />
-  },
-  encode: { 
-    label: "Encode", 
-    color: "bg-purple-500/20 text-purple-400 border-purple-500/30",
-    icon: <Mic className="w-3 h-3" />
-  },
-  qc: { 
-    label: "QC", 
-    color: "bg-orange-500/20 text-orange-400 border-orange-500/30",
-    icon: <CheckCircle className="w-3 h-3" />
-  },
-  finalizado: { 
-    label: "Finalizado", 
-    color: "bg-green-500/20 text-green-400 border-green-500/30",
-    icon: <CheckCircle className="w-3 h-3" />
-  },
-};
+const animeStages = [
+  { id: "aguardando-raw", label: "Aguardando Raw", color: "bg-slate-500", badge: "bg-slate-500/20 text-slate-300 border-slate-500/40" },
+  { id: "traducao", label: "Tradução", color: "bg-blue-500", badge: "bg-blue-500/20 text-blue-400 border-blue-500/30" },
+  { id: "revisao", label: "Revisão", color: "bg-yellow-500", badge: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30" },
+  { id: "timing", label: "Timing", color: "bg-pink-500", badge: "bg-pink-500/20 text-pink-400 border-pink-500/30" },
+  { id: "typesetting", label: "Typesetting", color: "bg-indigo-500", badge: "bg-indigo-500/20 text-indigo-400 border-indigo-500/30" },
+  { id: "quality-check", label: "Quality Check", color: "bg-orange-500", badge: "bg-orange-500/20 text-orange-400 border-orange-500/30" },
+  { id: "encode", label: "Encode", color: "bg-purple-500", badge: "bg-purple-500/20 text-purple-400 border-purple-500/30" },
+];
+
+const mangaStages = [
+  { id: "aguardando-raw", label: "Aguardando Raw", color: "bg-slate-500", badge: "bg-slate-500/20 text-slate-300 border-slate-500/40" },
+  { id: "traducao", label: "Tradução", color: "bg-blue-500", badge: "bg-blue-500/20 text-blue-400 border-blue-500/30" },
+  { id: "limpeza", label: "Limpeza", color: "bg-emerald-500", badge: "bg-emerald-500/20 text-emerald-400 border-emerald-500/30" },
+  { id: "redrawing", label: "Redrawing", color: "bg-cyan-500", badge: "bg-cyan-500/20 text-cyan-400 border-cyan-500/30" },
+  { id: "revisao", label: "Revisão", color: "bg-yellow-500", badge: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30" },
+  { id: "typesetting", label: "Typesetting", color: "bg-indigo-500", badge: "bg-indigo-500/20 text-indigo-400 border-indigo-500/30" },
+  { id: "quality-check", label: "Quality Check", color: "bg-orange-500", badge: "bg-orange-500/20 text-orange-400 border-orange-500/30" },
+];
 
 const workItems: WorkItem[] = [
-  { id: 1, anime: "Spy x Family", episode: 9, status: "traducao" },
-  { id: 2, anime: "Jujutsu Kaisen", episode: 16, status: "revisao" },
-  { id: 3, anime: "Frieren", episode: 21, status: "encode" },
-  { id: 4, anime: "Oshi no Ko", episode: 7, status: "qc" },
-  { id: 5, anime: "Bocchi the Rock!", episode: 3, status: "traducao" },
+  {
+    id: 1,
+    title: "Spy x Family",
+    entry: "Episódio 9",
+    kind: "anime",
+    currentStage: "traducao",
+    completedStages: ["aguardando-raw"],
+  },
+  {
+    id: 2,
+    title: "Jujutsu Kaisen",
+    entry: "Episódio 16",
+    kind: "anime",
+    currentStage: "timing",
+    completedStages: ["aguardando-raw", "traducao", "revisao"],
+  },
+  {
+    id: 3,
+    title: "Frieren",
+    entry: "Episódio 21",
+    kind: "anime",
+    currentStage: "quality-check",
+    completedStages: ["aguardando-raw", "traducao", "revisao", "timing", "typesetting"],
+  },
+  {
+    id: 4,
+    title: "Oshi no Ko",
+    entry: "Episódio 7",
+    kind: "anime",
+    currentStage: "typesetting",
+    completedStages: ["aguardando-raw", "traducao"],
+  },
+  {
+    id: 5,
+    title: "Bocchi the Rock!",
+    entry: "Episódio 3",
+    kind: "anime",
+    currentStage: "revisao",
+    completedStages: ["aguardando-raw", "traducao", "timing"],
+  },
+  {
+    id: 6,
+    title: "Kagurabachi",
+    entry: "Capítulo 32",
+    kind: "manga",
+    currentStage: "limpeza",
+    completedStages: ["aguardando-raw"],
+  },
+  {
+    id: 7,
+    title: "Sousou no Frieren",
+    entry: "Capítulo 128",
+    kind: "manga",
+    currentStage: "typesetting",
+    completedStages: ["aguardando-raw", "traducao", "limpeza", "redrawing", "revisao"],
+  },
+  {
+    id: 8,
+    title: "Chainsaw Man",
+    entry: "Capítulo 161",
+    kind: "manga",
+    currentStage: "revisao",
+    completedStages: ["aguardando-raw", "limpeza"],
+  },
 ];
 
 const WorkStatusCard = () => {
+  const itemsInProgress = workItems.filter((item) => {
+    const stages = item.kind === "anime" ? animeStages : mangaStages;
+    const completedSet = new Set([...item.completedStages, item.currentStage]);
+    const finalStage = stages[stages.length - 1]?.id;
+    return finalStage ? !completedSet.has(finalStage) : true;
+  });
+
   return (
     <Card className="bg-card border-border">
       <CardHeader className="px-4 pb-3 pt-4">
@@ -57,28 +118,41 @@ const WorkStatusCard = () => {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3 px-4 pb-4 pt-0">
-        {workItems.map((item) => {
-          const config = statusConfig[item.status];
+        {itemsInProgress.map((item) => {
+          const stages = item.kind === "anime" ? animeStages : mangaStages;
+          const completedSet = new Set([...item.completedStages, item.currentStage]);
+          const completedCount = stages.filter((stage) => completedSet.has(stage.id)).length;
+          const progress = Math.round((completedCount / stages.length) * 100);
+          const currentStage = stages.find((stage) => stage.id === item.currentStage) ?? stages[0];
+
           return (
             <div 
               key={item.id}
-              className="flex items-center justify-between p-2 rounded-md bg-secondary/50 hover:bg-secondary transition-colors"
+              className="rounded-md bg-secondary/50 p-3 hover:bg-secondary transition-colors"
             >
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-foreground truncate">
-                  {item.anime}
-                </p>
-                <span className="text-xs text-muted-foreground">
-                  Episódio {item.episode}
-                </span>
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-foreground truncate">
+                    {item.title}
+                  </p>
+                  <span className="text-xs text-muted-foreground">
+                    {item.entry}
+                  </span>
+                </div>
+                <Badge 
+                  variant="outline" 
+                  className={`flex-shrink-0 flex items-center gap-1 ${currentStage.badge}`}
+                >
+                  {currentStage.label}
+                </Badge>
               </div>
-              <Badge 
-                variant="outline" 
-                className={`ml-2 flex-shrink-0 flex items-center gap-1 ${config.color}`}
-              >
-                {config.icon}
-                {config.label}
-              </Badge>
+              <div className="mt-3">
+                <Progress
+                  value={progress}
+                  className="h-2"
+                  indicatorClassName={currentStage.color}
+                />
+              </div>
             </div>
           );
         })}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -3,17 +3,21 @@ import * as ProgressPrimitive from "@radix-ui/react-progress";
 
 import { cn } from "@/lib/utils";
 
+interface ProgressProps extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
+  indicatorClassName?: string;
+}
+
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  ProgressProps
+>(({ className, indicatorClassName, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className={cn("h-full w-full flex-1 bg-primary transition-all", indicatorClassName)}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>


### PR DESCRIPTION
### Motivation
- Replace the simple status label with explicit stage sequences for anime and manga so the "Em Progresso" card can represent multi-step workflows (including non-linear stage completion).
- Show a per-card progress bar colored by the current stage and remove items once the final stage is reached (e.g. `encode` for anime).

### Description
- Replace the old `WorkItem` shape with `title`, `entry`, `kind`, `currentStage`, and `completedStages`, and add `animeStages` and `mangaStages` stage arrays in `src/components/WorkStatusCard.tsx`.
- Compute progress as the fraction of completed stages (including the current stage), render a colored badge for the current stage, and filter out items that reached the final stage so they are no longer shown in the component.
- Update the card layout to include a progress bar per item and rearrange the item markup to show `title`/`entry` and the stage badge.
- Add `indicatorClassName` to `src/components/ui/progress.tsx` so each stage can supply its own progress-bar color.

### Testing
- Ran `npm install`, which completed successfully and installed project dependencies.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which started but surfaced an existing Vite/Tailwind CSS `@import` order warning coming from the repo stylesheet that prevented a clean run (warning reported during the session).
- Captured a UI screenshot via a Playwright script after the server started, which succeeded and produced `artifacts/work-status-card.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e3a34a204832596bed86cdc388350)