### PR TITLE
Atualiza layout dos cards de Lançamentos Recentes para grid com tags em hover

### DIFF
--- a/src/components/ReleasesSection.tsx
+++ b/src/components/ReleasesSection.tsx
@@ -23,6 +23,7 @@ const recentReleases = [
     date: "2024-01-28",
     author: "Marina Aoki",
     image: "/placeholder.svg",
+    tags: ["Anime", "Lançamento", "Especial"],
   },
   {
     id: 2,
@@ -33,6 +34,7 @@ const recentReleases = [
     date: "2024-01-25",
     author: "Lucas Sato",
     image: "/placeholder.svg",
+    tags: ["Anime", "Aviso"],
   },
   {
     id: 3,
@@ -43,6 +45,7 @@ const recentReleases = [
     date: "2024-01-22",
     author: "Renata Takeda",
     image: "/placeholder.svg",
+    tags: ["Anime", "Lançamento"],
   },
   {
     id: 4,
@@ -53,6 +56,7 @@ const recentReleases = [
     date: "2024-01-20",
     author: "Caio Matsumoto",
     image: "/placeholder.svg",
+    tags: ["Anime", "Especial"],
   },
   {
     id: 5,
@@ -63,6 +67,40 @@ const recentReleases = [
     date: "2024-01-18",
     author: "Bruna Ishida",
     image: "/placeholder.svg",
+    tags: ["Anime", "Ova"],
+  },
+  {
+    id: 6,
+    anime: "Dungeon Meshi",
+    episode: 9,
+    title: "Receitas improváveis no abismo",
+    excerpt: "O episódio trouxe momentos de humor e tensão. Comentamos como adaptamos piadas culinárias sem perder o tom original...",
+    date: "2024-01-16",
+    author: "Felipe Kawahara",
+    image: "/placeholder.svg",
+    tags: ["Anime", "Ona"],
+  },
+  {
+    id: 7,
+    anime: "Bocchi the Rock!",
+    episode: 4,
+    title: "Música, ansiedade e tradução criativa",
+    excerpt: "Lidamos com trocadilhos musicais e gírias modernas. Confira as decisões que tomamos para manter o ritmo...",
+    date: "2024-01-14",
+    author: "Lívia Nishimura",
+    image: "/placeholder.svg",
+    tags: ["Anime", "Especial"],
+  },
+  {
+    id: 8,
+    anime: "Solo Leveling",
+    episode: 3,
+    title: "A ascensão do caçador",
+    excerpt: "Explicamos como equilibramos termos técnicos e a fluidez da leitura para cenas de ação aceleradas...",
+    date: "2024-01-12",
+    author: "Daniel Mori",
+    image: "/placeholder.svg",
+    tags: ["Anime", "Lançamento"],
   },
 ];
 
@@ -76,39 +114,50 @@ const ReleasesSection = () => {
         
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Left side - Release cards (blog posts) */}
-          <div className="lg:col-span-2 space-y-4">
-            {recentReleases.map((release, index) => (
-              <Card
-                key={release.id}
-                className="bg-card border-border hover:border-primary/50 transition-all cursor-pointer group animate-fade-in"
-                style={{ animationDelay: `${index * 0.1}s` }}
-              >
-                <CardContent className="p-4 md:p-5 flex flex-col sm:flex-row gap-4">
-                  <div className="w-full sm:w-56 sm:h-32 h-52 rounded-md overflow-hidden flex-shrink-0 bg-secondary">
-                    <img
-                      src={release.image}
-                      alt={release.anime}
-                      className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                    />
-                  </div>
-                  <div className="flex-1 flex flex-col justify-between gap-3">
-                    <div className="space-y-2">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Badge variant="secondary" className="text-xs">
-                          {release.anime}
-                        </Badge>
-                        <span className="text-xs text-muted-foreground uppercase tracking-wide">
-                          EP {release.episode}
-                        </span>
+          <div className="lg:col-span-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6">
+              {recentReleases.map((release, index) => (
+                <Card
+                  key={release.id}
+                  className="bg-card border-border hover:border-primary/50 transition-all cursor-pointer group animate-fade-in"
+                  style={{ animationDelay: `${index * 0.1}s` }}
+                >
+                  <CardContent className="p-4 flex flex-col h-full gap-4">
+                    <div className="relative w-full h-44 sm:h-40 rounded-lg overflow-hidden bg-secondary">
+                      <img
+                        src={release.image}
+                        alt={release.anime}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                      />
+                      <div className="absolute left-3 top-3 flex flex-wrap gap-2 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-300">
+                        {release.tags.map((tag) => (
+                          <Badge
+                            key={tag}
+                            variant="secondary"
+                            className="text-[10px] uppercase tracking-wide bg-background/80 text-foreground"
+                          >
+                            {tag}
+                          </Badge>
+                        ))}
                       </div>
-                      <h3 className="text-lg font-semibold text-foreground group-hover:text-primary transition-colors">
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="secondary" className="text-xs">
+                        {release.anime}
+                      </Badge>
+                      <span className="text-xs text-muted-foreground uppercase tracking-wide">
+                        EP {release.episode}
+                      </span>
+                    </div>
+                    <div className="space-y-2">
+                      <h3 className="text-base font-semibold text-foreground group-hover:text-primary transition-colors">
                         {release.title}
                       </h3>
-                      <p className="text-sm text-muted-foreground line-clamp-2">
+                      <p className="text-sm text-muted-foreground line-clamp-3">
                         {release.excerpt}
                       </p>
                     </div>
-                    <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+                    <div className="mt-auto flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
                       <span className="inline-flex items-center gap-1.5">
                         <User className="h-4 w-4 text-primary/70" aria-hidden="true" />
                         {release.author}
@@ -118,10 +167,10 @@ const ReleasesSection = () => {
                         {new Date(release.date).toLocaleDateString("pt-BR")}
                       </span>
                     </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
             <Pagination className="justify-start pt-4">
               <PaginationContent>
                 <PaginationItem>


### PR DESCRIPTION
### Motivation
- Preencher melhor a seção de "Lançamentos Recentes" e fazer com que ela se estenda visualmente até o final da página usando um layout de cards lado a lado (2–3 por linha conforme o breakpoint). 
- Destacar a imagem do post como elemento principal e mostrar metadados (título, preview, autor, data) mantendo a sidebar inalterada.

### Description
- Converteu a listagem linear para uma grade responsiva com `sm:grid-cols-2` e `xl:grid-cols-3` e ajustou os estilos dos cards para ter a imagem em destaque. 
- Adicionou `tags` aos objetos de `recentReleases` e sobrepôs badges no canto superior esquerdo da imagem que aparecem apenas no `:hover`. 
- Ajustou truncamento de texto (`line-clamp-3`), posicionamento dos metadados e usou `group-hover` para pequenas animações de imagem e badges. 
- Não foram alterados componentes ou estilos da sidebar (`LatestEpisodeCard` e `WorkStatusCard` foram mantidos intactos). 

### Testing
- Executado `npm install` com sucesso para instalar dependências (relatórios de vulnerabilidades do `npm audit` não abordados automaticamente). 
- Inicializado o servidor de desenvolvimento com `npm run dev` e o Vite respondeu como pronto (acessível em `http://localhost:4173/`). 
- Tentativa automatizada de captura com Playwright falhou ao iniciar o navegador em ambiente headless devido a erro de execução do Chromium (SIGSEGV), portanto não foi gerada a screenshot automática.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4584405883258cb4d94016a2a9e2)