### PR TITLE
Ajusta proporção das imagens dos lançamentos para 3:2

### DIFF
--- a/src/components/ReleasesSection.tsx
+++ b/src/components/ReleasesSection.tsx
@@ -23,6 +23,7 @@ const recentReleases = [
     date: "2024-01-28",
     author: "Marina Aoki",
     image: "/placeholder.svg",
+    tags: ["Anime", "Lançamento", "Especial"],
   },
   {
     id: 2,
@@ -33,6 +34,7 @@ const recentReleases = [
     date: "2024-01-25",
     author: "Lucas Sato",
     image: "/placeholder.svg",
+    tags: ["Anime", "Aviso"],
   },
   {
     id: 3,
@@ -43,6 +45,7 @@ const recentReleases = [
     date: "2024-01-22",
     author: "Renata Takeda",
     image: "/placeholder.svg",
+    tags: ["Anime", "Lançamento"],
   },
   {
     id: 4,
@@ -53,6 +56,7 @@ const recentReleases = [
     date: "2024-01-20",
     author: "Caio Matsumoto",
     image: "/placeholder.svg",
+    tags: ["Anime", "Especial"],
   },
   {
     id: 5,
@@ -63,6 +67,40 @@ const recentReleases = [
     date: "2024-01-18",
     author: "Bruna Ishida",
     image: "/placeholder.svg",
+    tags: ["Anime", "Ova"],
+  },
+  {
+    id: 6,
+    anime: "Dungeon Meshi",
+    episode: 9,
+    title: "Receitas improváveis no abismo",
+    excerpt: "O episódio trouxe momentos de humor e tensão. Comentamos como adaptamos piadas culinárias sem perder o tom original...",
+    date: "2024-01-16",
+    author: "Felipe Kawahara",
+    image: "/placeholder.svg",
+    tags: ["Anime", "Ona"],
+  },
+  {
+    id: 7,
+    anime: "Bocchi the Rock!",
+    episode: 4,
+    title: "Música, ansiedade e tradução criativa",
+    excerpt: "Lidamos com trocadilhos musicais e gírias modernas. Confira as decisões que tomamos para manter o ritmo...",
+    date: "2024-01-14",
+    author: "Lívia Nishimura",
+    image: "/placeholder.svg",
+    tags: ["Anime", "Especial"],
+  },
+  {
+    id: 8,
+    anime: "Solo Leveling",
+    episode: 3,
+    title: "A ascensão do caçador",
+    excerpt: "Explicamos como equilibramos termos técnicos e a fluidez da leitura para cenas de ação aceleradas...",
+    date: "2024-01-12",
+    author: "Daniel Mori",
+    image: "/placeholder.svg",
+    tags: ["Anime", "Lançamento"],
   },
 ];
 
@@ -76,39 +114,50 @@ const ReleasesSection = () => {
         
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Left side - Release cards (blog posts) */}
-          <div className="lg:col-span-2 space-y-4">
-            {recentReleases.map((release, index) => (
-              <Card
-                key={release.id}
-                className="bg-card border-border hover:border-primary/50 transition-all cursor-pointer group animate-fade-in"
-                style={{ animationDelay: `${index * 0.1}s` }}
-              >
-                <CardContent className="p-4 md:p-5 flex flex-col sm:flex-row gap-4">
-                  <div className="w-full sm:w-56 sm:h-32 h-52 rounded-md overflow-hidden flex-shrink-0 bg-secondary">
-                    <img
-                      src={release.image}
-                      alt={release.anime}
-                      className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                    />
-                  </div>
-                  <div className="flex-1 flex flex-col justify-between gap-3">
-                    <div className="space-y-2">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Badge variant="secondary" className="text-xs">
-                          {release.anime}
-                        </Badge>
-                        <span className="text-xs text-muted-foreground uppercase tracking-wide">
-                          EP {release.episode}
-                        </span>
+          <div className="lg:col-span-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
+              {recentReleases.map((release, index) => (
+                <Card
+                  key={release.id}
+                  className="bg-card border-border hover:border-primary/50 transition-all cursor-pointer group animate-fade-in"
+                  style={{ animationDelay: `${index * 0.1}s` }}
+                >
+                  <CardContent className="p-5 flex flex-col h-full gap-4">
+                    <div className="relative w-full aspect-[3/2] rounded-lg overflow-hidden bg-secondary">
+                      <img
+                        src={release.image}
+                        alt={release.anime}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                      />
+                      <div className="absolute left-3 top-3 flex flex-wrap gap-2 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-300">
+                        {release.tags.map((tag) => (
+                          <Badge
+                            key={tag}
+                            variant="secondary"
+                            className="text-[10px] uppercase tracking-wide bg-background/80 text-foreground"
+                          >
+                            {tag}
+                          </Badge>
+                        ))}
                       </div>
-                      <h3 className="text-lg font-semibold text-foreground group-hover:text-primary transition-colors">
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="secondary" className="text-xs">
+                        {release.anime}
+                      </Badge>
+                      <span className="text-xs text-muted-foreground uppercase tracking-wide">
+                        EP {release.episode}
+                      </span>
+                    </div>
+                    <div className="space-y-2">
+                      <h3 className="text-base font-semibold text-foreground group-hover:text-primary transition-colors">
                         {release.title}
                       </h3>
-                      <p className="text-sm text-muted-foreground line-clamp-2">
+                      <p className="text-sm text-muted-foreground line-clamp-3">
                         {release.excerpt}
                       </p>
                     </div>
-                    <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+                    <div className="mt-auto flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
                       <span className="inline-flex items-center gap-1.5">
                         <User className="h-4 w-4 text-primary/70" aria-hidden="true" />
                         {release.author}
@@ -118,10 +167,10 @@ const ReleasesSection = () => {
                         {new Date(release.date).toLocaleDateString("pt-BR")}
                       </span>
                     </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
             <Pagination className="justify-start pt-4">
               <PaginationContent>
                 <PaginationItem>


### PR DESCRIPTION
### Motivation
- Aumentar o destaque visual das imagens dos cards na seção "Lançamentos Recentes" para melhor impacto visual.
- Atender ao feedback solicitando proporção 3:2 em vez de 16:9 para dar mais presença à mídia. 
- Manter a legibilidade e o layout de dois cartões por linha para equilibrar imagem e texto.

### Description
- Alterado o contêiner da imagem de `aspect-video` para `aspect-[3/2]` em `src/components/ReleasesSection.tsx` para aplicar a proporção 3:2. 
- Refatorado o layout dos cards para uma grade de até duas colunas (`sm:grid-cols-2`) com `p-5` nos `CardContent` e `gap-8` entre cards. 
- Adicionados badges de `tags` sobrepostos à imagem com transição em `:hover` e ajustado o truncamento do trecho para `line-clamp-3`. 
- Expandido o array `recentReleases` com amostras adicionais e a propriedade `tags` para suportar as badges na interface.

### Testing
- Executed `npm run dev` and the Vite dev server started successfully and served the app at the configured host/port. 
- Ran a Playwright script that launched Chromium, navigated to the dev server, and captured a screenshot saved as `artifacts/releases-section-3-2.png`, which completed successfully. 
- Noted a CSS `@import` order warning during runtime but it did not block the dev server or the Playwright run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4584405883258cb4d94016a2a9e2)