### PR TITLE
Diminuir espaçamento do card de convite do Discord

### DIFF
--- a/src/components/DiscordInviteCard.tsx
+++ b/src/components/DiscordInviteCard.tsx
@@ -18,11 +18,11 @@ const DiscordInviteCard = () => {
         <div className="space-y-2 rounded-xl border border-border/60 bg-background/40 p-3">
           <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
             <Users className="h-4 w-4 text-primary/80" aria-hidden="true" />
-            Comunidade Rainbow Fansub
+            Comunidade do Zuraaa!
           </div>
           <p className="text-xs text-muted-foreground leading-relaxed">
-            Receba alertas de lançamentos, participe de eventos e ajude a decidir
-            os próximos projetos.
+            Receba alertas de lançamentos, participe de eventos e fale
+            sobre os nossos projetos.
           </p>
         </div>
         <Button asChild className="w-full">

--- a/src/components/DiscordInviteCard.tsx
+++ b/src/components/DiscordInviteCard.tsx
@@ -1,0 +1,42 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { MessageCircle, Users } from "lucide-react";
+
+const DiscordInviteCard = () => {
+  return (
+    <Card className="bg-card border-border">
+      <CardHeader className="px-4 pb-3 pt-4">
+        <CardTitle className="text-lg font-semibold text-foreground flex items-center gap-2">
+          <MessageCircle className="w-4 h-4 text-primary" />
+          Entre no Discord
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Converse com a equipe e acompanhe novidades em tempo real.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3 px-4 pb-4 pt-0">
+        <div className="space-y-2 rounded-xl border border-border/60 bg-background/40 p-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <Users className="h-4 w-4 text-primary/80" aria-hidden="true" />
+            Comunidade Rainbow Fansub
+          </div>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Receba alertas de lançamentos, participe de eventos e ajude a decidir
+            os próximos projetos.
+          </p>
+        </div>
+        <Button asChild className="w-full">
+          <a
+            href="https://discord.gg/BAHKhdX2ju"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Entrar no servidor
+          </a>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DiscordInviteCard;

--- a/src/components/ReleasesSection.tsx
+++ b/src/components/ReleasesSection.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/pagination";
 import LatestEpisodeCard from "./LatestEpisodeCard";
 import WorkStatusCard from "./WorkStatusCard";
+import DiscordInviteCard from "./DiscordInviteCard";
 import { CalendarDays, User } from "lucide-react";
 
 // Mock data for recent releases (blog posts about episodes)
@@ -199,9 +200,10 @@ const ReleasesSection = () => {
           </div>
           
           {/* Right side - Sidebar */}
-          <div className="space-y-6">
+          <div className="flex h-full flex-col gap-6">
             <LatestEpisodeCard />
             <WorkStatusCard />
+            <DiscordInviteCard />
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Tornar o card de convite do Discord mais compacto na sidebar, sem forçar altura, conforme feedback para que não ocupe espaço extra na coluna direita.

### Description
- Atualiza `src/components/DiscordInviteCard.tsx` removendo `flex-1` do `Card` e ajustando classes para reduzir padding e gaps (`CardContent` passa a ser `flex flex-col gap-3 px-4 pb-4 pt-0` e o painel interno passa para `space-y-2 ... p-3`).
- Mantém o botão de CTA com `w-full` e o link para `https://discord.gg/BAHKhdX2ju` aberto em nova aba.
- O componente continua importado na sidebar de lançamentos para exibição junto dos outros cards.

### Testing
- Executed `npm install` successfully to restore dependencies.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which served the app via Vite successfully.
- Ran a Playwright script to capture a screenshot of the releases page with the compact Discord card, and the screenshot artifact was produced successfully.
- No unit tests were added or modified for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4ad2b3048325a0aaf036c212738e)