### PR TITLE
Releases: conditional pagination + Portuguese labels

### DIFF
--- a/src/components/ReleasesSection.tsx
+++ b/src/components/ReleasesSection.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -106,6 +107,15 @@ const recentReleases = [
 ];
 
 const ReleasesSection = () => {
+  const pageSize = 8;
+  const [currentPage, setCurrentPage] = useState(1);
+  const totalPages = Math.ceil(recentReleases.length / pageSize);
+  const pagedReleases = useMemo(() => {
+    const startIndex = (currentPage - 1) * pageSize;
+    return recentReleases.slice(startIndex, startIndex + pageSize);
+  }, [currentPage]);
+  const showPagination = totalPages > 1;
+
   return (
     <section className="py-16 px-6 md:px-12 bg-background">
       <div className="max-w-7xl mx-auto">
@@ -117,7 +127,7 @@ const ReleasesSection = () => {
           {/* Left side - Release cards (blog posts) */}
           <div className="lg:col-span-2">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
-              {recentReleases.map((release, index) => (
+              {pagedReleases.map((release, index) => (
                 <Card
                   key={release.id}
                   className="bg-card border-border hover:border-primary/50 transition-all cursor-pointer group animate-fade-in"
@@ -172,31 +182,57 @@ const ReleasesSection = () => {
                 </Card>
               ))}
             </div>
-            <Pagination className="justify-start pt-4">
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious href="#" className="text-xs" />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink href="#" size="default" isActive className="text-xs">
-                    1
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink href="#" size="default" className="text-xs">
-                    2
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink href="#" size="default" className="text-xs">
-                    3
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationNext href="#" className="text-xs" />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
+            {showPagination ? (
+              <Pagination className="justify-start pt-4">
+                <PaginationContent>
+                  <PaginationItem>
+                    <PaginationPrevious
+                      href="#"
+                      className="text-xs"
+                      aria-disabled={currentPage === 1}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        if (currentPage > 1) {
+                          setCurrentPage((page) => page - 1);
+                        }
+                      }}
+                    />
+                  </PaginationItem>
+                  {Array.from({ length: totalPages }, (_, index) => {
+                    const page = index + 1;
+                    return (
+                      <PaginationItem key={page}>
+                        <PaginationLink
+                          href="#"
+                          size="default"
+                          isActive={page === currentPage}
+                          className="text-xs"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            setCurrentPage(page);
+                          }}
+                        >
+                          {page}
+                        </PaginationLink>
+                      </PaginationItem>
+                    );
+                  })}
+                  <PaginationItem>
+                    <PaginationNext
+                      href="#"
+                      className="text-xs"
+                      aria-disabled={currentPage === totalPages}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        if (currentPage < totalPages) {
+                          setCurrentPage((page) => page + 1);
+                        }
+                      }}
+                    />
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
+            ) : null}
           </div>
           
           {/* Right side - Sidebar */}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -7,7 +7,7 @@ import { ButtonProps, buttonVariants } from "@/components/ui/button";
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav
     role="navigation"
-    aria-label="pagination"
+    aria-label="paginação"
     className={cn("mx-auto flex w-full justify-center", className)}
     {...props}
   />
@@ -47,16 +47,16 @@ const PaginationLink = ({ className, isActive, size = "icon", ...props }: Pagina
 PaginationLink.displayName = "PaginationLink";
 
 const PaginationPrevious = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink aria-label="Go to previous page" size="default" className={cn("gap-1 pl-2.5", className)} {...props}>
+  <PaginationLink aria-label="Ir para a página anterior" size="default" className={cn("gap-1 pl-2.5", className)} {...props}>
     <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
+    <span>Anterior</span>
   </PaginationLink>
 );
 PaginationPrevious.displayName = "PaginationPrevious";
 
 const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink aria-label="Go to next page" size="default" className={cn("gap-1 pr-2.5", className)} {...props}>
-    <span>Next</span>
+  <PaginationLink aria-label="Ir para a próxima página" size="default" className={cn("gap-1 pr-2.5", className)} {...props}>
+    <span>Próxima</span>
     <ChevronRight className="h-4 w-4" />
   </PaginationLink>
 );
@@ -65,7 +65,7 @@ PaginationNext.displayName = "PaginationNext";
 const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<"span">) => (
   <span aria-hidden className={cn("flex h-9 w-9 items-center justify-center", className)} {...props}>
     <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More pages</span>
+    <span className="sr-only">Mais páginas</span>
   </span>
 );
 PaginationEllipsis.displayName = "PaginationEllipsis";


### PR DESCRIPTION
### Motivation
- Show pagination only when there are more than eight posts so the UI remains simple for small lists.
- Localize pagination controls and accessibility text to Portuguese for better UX.
- Provide interactive previous/next and numbered page buttons so users can navigate large release lists client-side.

### Description
- Add client-side pagination to `src/components/ReleasesSection.tsx` using `useState` and `useMemo`, set `pageSize = 8`, compute `totalPages`, and slice `recentReleases` into `pagedReleases`.
- Render numeric page buttons dynamically with `Array.from({ length: totalPages })` and wire click handlers to `setCurrentPage`, and implement `Previous`/`Next` handlers with disabled checks.
- Only render the `<Pagination>` block when `showPagination` (i.e., `totalPages > 1`).
- Localize the pagination component in `src/components/ui/pagination.tsx` by replacing labels/aria-text with Portuguese (`paginação`, `Anterior`, `Próxima`, `Mais páginas`).

### Testing
- Ran `npm install` to install dependencies and the command completed successfully.
- Launched the dev server with `npm run dev` and the app served locally at `http://localhost:4173/`.
- Executed a Playwright script to capture a screenshot of the releases section which produced `artifacts/releases-pagination.png`, and no unit tests (`vitest`) were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4d46007c8325b83bc38f99ea10de)