### PR TITLE
Enhance navbar search results (project cards, Discord label, outside-click close)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,81 @@
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
+import { Badge } from "@/components/ui/badge";
 
 const Header = () => {
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLDivElement | null>(null);
+
+  const projectItems = [
+    {
+      label: "Aurora no Horizonte",
+      href: "/projetos/aurora-no-horizonte",
+      image: "/placeholder.svg",
+      synopsis: "Uma jornada sci-fi sobre amizade, esperança e o renascimento de uma nave perdida.",
+      tags: ["Anime", "Sci-fi", "Drama"],
+    },
+    {
+      label: "Nekomata: Eclipse",
+      href: "/projetos/nekomata-eclipse",
+      image: "/placeholder.svg",
+      synopsis: "Mangá sobrenatural que acompanha um clã felino e seus pactos com o submundo.",
+      tags: ["Mangá", "Sobrenatural", "Ação"],
+    },
+    {
+      label: "Rainbow Pulse",
+      href: "/projetos/rainbow-pulse",
+      image: "/placeholder.svg",
+      synopsis: "Equipe de idols futuristas luta para manter a música viva em uma metrópole distópica.",
+      tags: ["Anime", "Música", "Ficção"],
+    },
+  ];
+
+  const postItems = [
+    { label: "Atualização de comunidade", href: "/posts/comunidade" },
+    { label: "Diário de desenvolvimento", href: "/posts/devlog" },
+    { label: "Guia para novos membros", href: "/posts/guia-novos-membros" },
+  ];
+
+  const filteredProjects = useMemo(() => {
+    if (!query.trim()) {
+      return [];
+    }
+    const lowerQuery = query.toLowerCase();
+    return projectItems.filter((item) => {
+      const searchableText = [item.label, item.synopsis, item.tags.join(" ")].join(" ").toLowerCase();
+      return searchableText.includes(lowerQuery);
+    });
+  }, [projectItems, query]);
+
+  const filteredPosts = useMemo(() => {
+    if (!query.trim()) {
+      return [];
+    }
+    const lowerQuery = query.toLowerCase();
+    return postItems.filter((item) => item.label.toLowerCase().includes(lowerQuery));
+  }, [postItems, query]);
+
+  const showResults = isSearchOpen && query.trim().length > 0;
+  const hasResults = filteredProjects.length > 0 || filteredPosts.length > 0;
+
+  useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (searchRef.current && !searchRef.current.contains(event.target as Node)) {
+        setIsSearchOpen(false);
+        setQuery("");
+      }
+    };
+
+    if (isSearchOpen) {
+      document.addEventListener("mousedown", handleOutsideClick);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick);
+    };
+  }, [isSearchOpen]);
+
   return (
     <header className="fixed top-0 left-0 right-0 z-50 px-6 py-4 md:px-12">
       <nav className="flex items-center justify-between">
@@ -8,31 +83,145 @@ const Header = () => {
           NEKOMATA
         </Link>
         
-        <div className="flex items-center gap-4 md:gap-8">
-          <Link 
-            to="/" 
-            className="hidden md:block text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Início
-          </Link>
-          <Link 
-            to="/animes" 
-            className="hidden md:block text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Animes
-          </Link>
-          <Link 
-            to="/lancamentos" 
-            className="hidden md:block text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Lançamentos
-          </Link>
-          <Link 
-            to="/login" 
-            className="text-sm font-medium px-4 py-2 rounded-lg bg-secondary hover:bg-secondary/80 text-foreground transition-colors"
-          >
-            Entrar
-          </Link>
+        <div className="flex items-center gap-3 md:gap-6">
+          <div className="hidden md:flex items-center gap-6 text-sm font-medium text-muted-foreground">
+            <Link to="/" className="hover:text-foreground transition-colors">
+              Início
+            </Link>
+            <Link to="/projetos" className="hover:text-foreground transition-colors">
+              Projetos
+            </Link>
+            <Link to="/equipe" className="hover:text-foreground transition-colors">
+              Equipe
+            </Link>
+            <a
+              href="https://discord.gg/nekogroup"
+              className="hover:text-foreground transition-colors"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Discord
+            </a>
+            <a
+              href="https://discord.gg/nekogroup"
+              className="hover:text-foreground transition-colors"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Recrutamento
+            </a>
+            <Link to="/sobre" className="hover:text-foreground transition-colors">
+              Sobre
+            </Link>
+          </div>
+
+          <div className="relative flex items-center" ref={searchRef}>
+            <div
+              className={`flex items-center gap-2 rounded-full border border-transparent bg-secondary/30 px-3 py-2 transition-all duration-300 ${
+                isSearchOpen ? "w-60 md:w-72 border-border bg-secondary/70" : "w-11"
+              }`}
+            >
+              <button
+                type="button"
+                aria-label="Abrir pesquisa"
+                onClick={() => setIsSearchOpen((prev) => !prev)}
+                className="text-foreground transition-colors hover:text-primary"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-4 w-4"
+                >
+                  <circle cx="11" cy="11" r="8" />
+                  <path d="m21 21-4.3-4.3" />
+                </svg>
+              </button>
+              {isSearchOpen && (
+                <input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Pesquisar projetos e posts"
+                  className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+                />
+              )}
+            </div>
+
+            {showResults && (
+              <div className="absolute right-0 top-12 w-80 rounded-xl border border-border/60 bg-background/95 p-4 shadow-lg backdrop-blur">
+                {filteredProjects.length > 0 && (
+                  <div className="mb-4">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Projetos
+                    </p>
+                    <ul className="mt-3 space-y-3">
+                      {filteredProjects.map((item) => (
+                        <li key={item.href}>
+                          <Link
+                            to={item.href}
+                            className="group flex gap-3 rounded-lg border border-border/60 bg-background/40 p-3 transition hover:border-primary/40 hover:bg-primary/5"
+                          >
+                            <div className="w-16 flex-shrink-0 overflow-hidden rounded-md bg-secondary aspect-[2/3]">
+                              <img
+                                src={item.image}
+                                alt={item.label}
+                                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                              />
+                            </div>
+                            <div className="min-w-0">
+                              <p className="text-sm font-semibold text-foreground group-hover:text-primary">
+                                {item.label}
+                              </p>
+                              <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+                                {item.synopsis}
+                              </p>
+                              <div className="mt-2 flex flex-wrap gap-1.5">
+                                {item.tags.map((tag) => (
+                                  <Badge key={tag} variant="secondary" className="text-[9px] uppercase">
+                                    {tag}
+                                  </Badge>
+                                ))}
+                              </div>
+                            </div>
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {filteredPosts.length > 0 && (
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Posts
+                    </p>
+                    <ul className="mt-2 space-y-2">
+                      {filteredPosts.map((item) => (
+                        <li key={item.href}>
+                          <Link
+                            to={item.href}
+                            className="text-sm text-foreground transition-colors hover:text-primary"
+                          >
+                            {item.label}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {!hasResults && (
+                  <p className="text-sm text-muted-foreground">
+                    Nenhum resultado encontrado para a sua pesquisa.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       </nav>
     </header>


### PR DESCRIPTION
### Motivation
- Tornar a pesquisa da navbar mais informativa exibindo cartões de projetos (capa, sinopse e tags) para os itens de anime/mangá.  
- Ajustar o rótulo do link do Discord para o texto solicitado.  
- Fechar e limpar a pesquisa quando o usuário clicar fora da área para restaurar o estado anterior da UI.

### Description
- Adicionado estado e referências de pesquisa em `src/components/Header.tsx` com `useState` e `useRef` e importado `Badge` para exibir tags.  
- Substituídos os `projectItems` por objetos enriquecidos que incluem `image`, `synopsis` e `tags`, e atualizado `filteredProjects` para buscar também em `synopsis` e `tags`.  
- Implementado manipulador de clique externo com `useEffect` que fecha a pesquisa e limpa o `query` quando o clique ocorre fora do contêiner de pesquisa.  
- Atualizado o markup da dropdown de resultados para renderizar cartões com imagem usando a mesma proporção (`aspect-[2/3]`) usada em `LatestEpisodeCard`, sinopse truncada e badges de tags, e alterado o rótulo do link para `Discord`.

### Testing
- Iniciado o servidor de desenvolvimento com `npm run dev -- --host 0.0.0.0 --port 4173` e o Vite respondeu como pronto (sucesso), com um aviso de CSS `@import` observado mas sem impacto na execução.  
- Executado um script Playwright que abriu `http://127.0.0.1:4173/`, clicou no botão de pesquisa (`aria-label="Abrir pesquisa"`), preencheu `manga` e gerou a captura `artifacts/navbar-search-updated.png` (sucesso).  
- Não foram executadas suítes de testes unitários automatizados adicionais neste PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4fadc7d48325afd00537e1a42d2a)