### PR TITLE
Add site footer layout

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,184 @@
+import { Facebook, Instagram, Twitter, Youtube, MessageCircle } from "lucide-react";
+
+const footerColumns = [
+  {
+    title: "Nekomata",
+    links: [
+      { label: "Sobre", href: "/sobre" },
+      { label: "Equipe", href: "/equipe" },
+      { label: "Contato", href: "/contato" },
+    ],
+  },
+  {
+    title: "Ajude nossa equipe",
+    links: [
+      { label: "Recrutamento", href: "/recrutamento" },
+      { label: "Doações", href: "/doacoes" },
+      { label: "Vantagens de apoiador", href: "/apoiadores" },
+    ],
+  },
+  {
+    title: "Links úteis",
+    links: [
+      { label: "Projetos", href: "/projetos" },
+      { label: "FAQ", href: "/faq" },
+      { label: "Política de privacidade", href: "/privacidade" },
+      { label: "Reportar erros", href: "/suporte" },
+    ],
+  },
+];
+
+const socialLinks = [
+  {
+    label: "Instagram",
+    href: "https://instagram.com",
+    icon: Instagram,
+  },
+  {
+    label: "Facebook",
+    href: "https://facebook.com",
+    icon: Facebook,
+  },
+  {
+    label: "Twitter",
+    href: "https://twitter.com",
+    icon: Twitter,
+  },
+  {
+    label: "YouTube",
+    href: "https://youtube.com",
+    icon: Youtube,
+  },
+  {
+    label: "Discord",
+    href: "https://discord.gg/nekogroup",
+    icon: MessageCircle,
+  },
+];
+
+const partnerLinks = [
+  { label: "AniDB", href: "https://anidb.net" },
+  { label: "MyAnimeList", href: "https://myanimelist.net" },
+  { label: "Info Anime", href: "https://infoanime.com.br" },
+];
+
+const Footer = () => {
+  return (
+    <footer className="mt-16 border-t border-border/60 bg-card/60">
+      <div className="mx-auto max-w-7xl px-6 md:px-12 py-14">
+        <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr_1fr_1.1fr]">
+          <div className="space-y-4">
+            <p className="text-3xl font-black tracking-widest text-gradient-rainbow">NEKOMATA</p>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Fansub dedicada a trazer histórias inesquecíveis com o carinho que a comunidade merece.
+              Traduzimos por paixão, respeitando autores e apoiando o consumo legal das obras.
+            </p>
+            <div className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-secondary/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-primary">
+              CC BY-NC-SA 4.0 • Uso não comercial
+            </div>
+          </div>
+
+          {footerColumns.map((column) => (
+            <div key={column.title} className="space-y-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                {column.title}
+              </p>
+              <ul className="space-y-2 text-sm">
+                {column.links.map((link) => (
+                  <li key={link.label}>
+                    <a
+                      href={link.href}
+                      className="text-foreground/80 transition-colors hover:text-primary"
+                    >
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+
+          <div className="space-y-5">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                Siga-nos
+              </p>
+              <div className="mt-4 space-y-2">
+                {socialLinks.map((link) => {
+                  const Icon = link.icon;
+                  return (
+                    <a
+                      key={link.label}
+                      href={link.href}
+                      className="group flex items-center gap-3 text-sm text-foreground/80 transition-colors hover:text-primary"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <span className="flex h-8 w-8 items-center justify-center rounded-full border border-border/60 bg-secondary/70 text-primary/80 transition group-hover:border-primary/40 group-hover:text-primary">
+                        <Icon className="h-4 w-4" aria-hidden="true" />
+                      </span>
+                      {link.label}
+                    </a>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Parceiros</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {partnerLinks.map((partner) => (
+                  <a
+                    key={partner.label}
+                    href={partner.href}
+                    className="rounded-full border border-border/60 bg-secondary/60 px-3 py-1 text-xs font-medium text-foreground/80 transition-colors hover:border-primary/40 hover:text-primary"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {partner.label}
+                  </a>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-12 grid gap-6 border-t border-border/60 pt-8 lg:grid-cols-[1.3fr_1fr]">
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              Todo o conteúdo divulgado aqui pertence a seus respectivos autores e editoras. As traduções
+              são realizadas por fãs, sem fins lucrativos, com o objetivo de divulgar as obras no Brasil.
+            </p>
+            <p>
+              Caso goste de alguma obra, apoie a versão oficial. A venda de materiais legendados pela equipe
+              é proibida.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 rounded-2xl border border-primary/20 bg-gradient-card p-5 text-sm text-foreground">
+            <p className="font-semibold text-primary">Atribuição • Não Comercial • Compartilhe Igual</p>
+            <p className="text-muted-foreground">
+              Este site segue a licença Creative Commons BY-NC-SA. Você pode compartilhar com créditos, sem
+              fins comerciais e mantendo a mesma licença.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-border/60 bg-background/40">
+        <div className="mx-auto flex max-w-7xl flex-col gap-2 px-6 py-6 text-xs text-muted-foreground md:flex-row md:items-center md:justify-between md:px-12">
+          <p>© 2014 - 2026 Nekomata Fansub. Feito por fãs para fãs.</p>
+          <div className="flex flex-wrap gap-4">
+            <a href="/termos" className="transition-colors hover:text-primary">
+              Termos de uso
+            </a>
+            <a href="/privacidade" className="transition-colors hover:text-primary">
+              Política de privacidade
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import Header from "@/components/Header";
 import HeroSection from "@/components/HeroSection";
 import ReleasesSection from "@/components/ReleasesSection";
+import Footer from "@/components/Footer";
 
 const Index = () => {
   return (
@@ -8,6 +9,7 @@ const Index = () => {
       <Header />
       <HeroSection />
       <ReleasesSection />
+      <Footer />
     </div>
   );
 };


### PR DESCRIPTION
### Motivation
- Provide a site footer that surfaces navigation, social links, partners and licensing information while preserving the project visual identity and layout.
- Make the footer available on the homepage so pages have a consistent global footer section.

### Description
- Added a new footer component at `src/components/Footer.tsx` that contains column navigation, social icons (using `lucide-react`), partner chips and license/disclaimer blocks.
- Imported and rendered the new `Footer` in `src/pages/Index.tsx` to include it on the home page.
- Footer layout relies on existing Tailwind utility classes and project design tokens (gradients, muted/primary colors) to keep consistent styling.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and loaded the home page, then captured a full-page screenshot with a Playwright script (artifact: `artifacts/footer.png`).
- The dev run surfaced a Vite CSS ordering error: `@import must precede all other statements` in `src/index.css`, which affected CSS processing during the session.
- No additional unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e52ef80848325afcfc093553cc710)