### PR TITLE
Footer: move Info Anime to Links úteis, remove Parceiros, align social links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -24,6 +24,7 @@ const footerColumns = [
       { label: "FAQ", href: "/faq" },
       { label: "Política de privacidade", href: "/privacidade" },
       { label: "Reportar erros", href: "/suporte" },
+      { label: "Info Anime", href: "https://infoanime.com.br" },
     ],
   },
 ];
@@ -56,12 +57,6 @@ const socialLinks = [
   },
 ];
 
-const partnerLinks = [
-  { label: "AniDB", href: "https://anidb.net" },
-  { label: "MyAnimeList", href: "https://myanimelist.net" },
-  { label: "Info Anime", href: "https://infoanime.com.br" },
-];
-
 const Footer = () => {
   return (
     <footer className="mt-16 border-t border-border/60 bg-card/60">
@@ -73,9 +68,6 @@ const Footer = () => {
               Fansub dedicada a trazer histórias inesquecíveis com o carinho que a comunidade merece.
               Traduzimos por paixão, respeitando autores e apoiando o consumo legal das obras.
             </p>
-            <div className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-secondary/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-primary">
-              CC BY-NC-SA 4.0 • Uso não comercial
-            </div>
           </div>
 
           {footerColumns.map((column) => (
@@ -98,47 +90,28 @@ const Footer = () => {
             </div>
           ))}
 
-          <div className="space-y-5">
-            <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                Siga-nos
-              </p>
-              <div className="mt-4 space-y-2">
-                {socialLinks.map((link) => {
-                  const Icon = link.icon;
-                  return (
-                    <a
-                      key={link.label}
-                      href={link.href}
-                      className="group flex items-center gap-3 text-sm text-foreground/80 transition-colors hover:text-primary"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      <span className="flex h-8 w-8 items-center justify-center rounded-full border border-border/60 bg-secondary/70 text-primary/80 transition group-hover:border-primary/40 group-hover:text-primary">
-                        <Icon className="h-4 w-4" aria-hidden="true" />
-                      </span>
-                      {link.label}
-                    </a>
-                  );
-                })}
-              </div>
-            </div>
-
-            <div>
-              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Parceiros</p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {partnerLinks.map((partner) => (
+          <div className="space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              Siga-nos
+            </p>
+            <div className="space-y-2">
+              {socialLinks.map((link) => {
+                const Icon = link.icon;
+                return (
                   <a
-                    key={partner.label}
-                    href={partner.href}
-                    className="rounded-full border border-border/60 bg-secondary/60 px-3 py-1 text-xs font-medium text-foreground/80 transition-colors hover:border-primary/40 hover:text-primary"
+                    key={link.label}
+                    href={link.href}
+                    className="group flex items-center gap-3 text-sm text-foreground/80 transition-colors hover:text-primary"
                     target="_blank"
                     rel="noreferrer"
                   >
-                    {partner.label}
+                    <span className="flex h-8 w-8 items-center justify-center rounded-full border border-border/60 bg-secondary/70 text-primary/80 transition group-hover:border-primary/40 group-hover:text-primary">
+                      <Icon className="h-4 w-4" aria-hidden="true" />
+                    </span>
+                    {link.label}
                   </a>
-                ))}
-              </div>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -61,7 +61,7 @@ const Footer = () => {
   return (
     <footer className="mt-16 border-t border-border/60 bg-card/60">
       <div className="mx-auto max-w-7xl px-6 md:px-12 py-14">
-        <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr_1fr_1.1fr]">
+        <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr_1fr_1fr_1.1fr]">
           <div className="space-y-4">
             <p className="text-3xl font-black tracking-widest text-gradient-rainbow">NEKOMATA</p>
             <p className="text-sm text-muted-foreground leading-relaxed">


### PR DESCRIPTION
### Motivation
- Ajustar o layout do rodapé para que a coluna “Siga-nos” fique ao lado das outras colunas em vez de em uma linha separada.
- Mover o link `Info Anime` para a seção `Links úteis` e remover a seção de `Parceiros` redundante.
- Remover o badge CC curto no topo do rodapé deixando apenas o bloco detalhado de licença mais abaixo.

### Description
- Atualizado `src/components/Footer.tsx` para adicionar `Info Anime` à lista `Links úteis` e remover a definição `partnerLinks`.
- Removida a seção de `Parceiros` do JSX e ajustada a marcação de `Siga-nos` para ser uma coluna normal alinhada com as demais colunas.
- Eliminado o badge compacto `CC BY-NC-SA 4.0 • Uso não comercial` no bloco superior, mantendo apenas o painel detalhado de licença na parte inferior.

### Testing
- Executado `npm run dev` e o servidor Vite iniciou com sucesso (pronto), apresentando apenas um aviso de CSS `@import` que não quebrou o servidor.
- Executado um script Playwright para capturar um screenshot completo da página e o script completou com sucesso gerando `artifacts/footer-update.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e59493814832597e806a7568d83a6)