### PR TITLE
Use globe icon for hero CTA

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import heroImage from "@/assets/hero-illya.jpg";
+import { Globe, Play } from "lucide-react";
 import {
   Carousel,
   CarouselContent,
@@ -153,10 +154,12 @@ const HeroSection = () => {
                       className="mt-8 flex flex-wrap gap-4 animate-slide-up opacity-0"
                       style={{ animationDelay: "0.4s" }}
                     >
-                      <button className="px-6 py-3 font-semibold rounded-lg transition-all hover:scale-105 hover:brightness-110 bg-[color:var(--hero-accent,hsl(var(--primary)))] text-[color:var(--hero-accent-foreground,hsl(var(--primary-foreground)))]">
+                      <button className="inline-flex items-center gap-2 px-6 py-3 font-semibold rounded-lg transition-all hover:scale-105 hover:brightness-110 bg-[color:var(--hero-accent,hsl(var(--primary)))] text-[color:var(--hero-accent-foreground,hsl(var(--primary-foreground)))]">
+                        <Globe className="h-4 w-4" />
                         Acessar Página
                       </button>
-                      <button className="px-6 py-3 font-semibold rounded-lg transition-all hover:scale-105 border border-border/40 bg-background/70 text-foreground hover:bg-background/90">
+                      <button className="inline-flex items-center gap-2 px-6 py-3 font-semibold rounded-lg transition-all hover:scale-105 border border-border/40 bg-background/70 text-foreground hover:bg-background/90">
+                        <Play className="h-4 w-4" />
                         Assistir Trailer
                       </button>
                     </div>


### PR DESCRIPTION
### Motivation
- Replace the informational arrow icon with a globe icon for the "Acessar Página" CTA to better convey navigation to the page.

### Description
- Update `src/components/HeroSection.tsx` to import `Globe` from `lucide-react` and render `<Globe className="h-4 w-4" />` inside the primary CTA button.
- Ensure both CTA buttons use `inline-flex items-center gap-2` for correct icon and text alignment.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served successfully over HTTP; this step succeeded.
- Captured a UI screenshot with a Playwright script saved as `artifacts/hero-buttons-icons.png` to verify the globe and play icons render correctly; this step succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5ab1f2788325aff73111af40f8e4)