### PR TITLE
Adicionar blur e sombra à navbar ao rolar

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 const Header = () => {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [isScrolled, setIsScrolled] = useState(false);
   const searchRef = useRef<HTMLDivElement | null>(null);
 
   const projectItems = [
@@ -76,8 +77,27 @@ const Header = () => {
     };
   }, [isSearchOpen]);
 
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > 12);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 px-6 py-4 md:px-12">
+    <header
+      className={`fixed top-0 left-0 right-0 z-50 px-6 py-4 transition-all duration-300 md:px-12 ${
+        isScrolled
+          ? "bg-background/70 shadow-lg shadow-black/10 backdrop-blur-xl"
+          : "bg-transparent"
+      }`}
+    >
       <nav className="flex items-center justify-between">
         <Link to="/" className="text-2xl md:text-3xl font-black tracking-wider text-foreground">
           NEKOMATA


### PR DESCRIPTION
### Motivation
- Melhorar a legibilidade da navbar quando a página é rolada aplicando um blur/sombra mais forte e uma transição suave no fundo.

### Description
- Adiciona o estado `isScrolled` e um `useEffect` que atualiza `isScrolled` com base em `window.scrollY > 12` no arquivo `src/components/Header.tsx`.
- Aplica classes condicionais no elemento `<header>` para alternar entre `bg-transparent` e `bg-background/70 shadow-lg shadow-black/10 backdrop-blur-xl` com `transition-all duration-300` ao rolar.
- Mudança limitada a um único componente visual sem alterar a estrutura do DOM ou outros componentes.

### Testing
- Executado o servidor de desenvolvimento com `npm run dev`, que permaneceu disponível apesar de um aviso de CSS `@import` do Vite; o servidor subiu corretamente.
- Executado um script Playwright que abriu `http://127.0.0.1:4173/`, rolou a página e gerou a captura `artifacts/navbar-shadow-scroll.png`, e o script concluiu com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5c71891c832596e154b45e4c144c)