### PR TITLE
Make project embed image and title link to project page

### DIFF
--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -151,29 +151,34 @@ const Post = () => {
 
               <Card className="border-border bg-card shadow-sm">
                 <CardContent className="space-y-4 p-4">
-                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
-                    <div className="mb-4 w-full overflow-hidden rounded-xl border border-border sm:w-32">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-stretch">
+                    <a
+                      href="/projeto/sono-bisque-doll"
+                      className="w-full overflow-hidden rounded-xl border border-border transition sm:w-36 sm:self-stretch hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                    >
                       <img
                         src={projectEmbed.image}
                         alt={projectEmbed.title}
-                        className="aspect-[2/3] w-full object-cover"
+                        className="h-full w-full object-cover"
                       />
-                    </div>
+                    </a>
                     <div className="flex flex-1 flex-col gap-2.5">
                       <div className="flex flex-wrap items-start justify-between gap-2">
                         <div className="space-y-1">
-                          <h3 className="text-lg font-semibold text-foreground">{projectEmbed.title}</h3>
+                          <a
+                            href="/projeto/sono-bisque-doll"
+                            className="text-lg font-semibold text-foreground transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                          >
+                            {projectEmbed.title}
+                          </a>
                           <p className="text-sm text-muted-foreground">{projectEmbed.synopsis}</p>
                         </div>
                       </div>
-                      <div className="flex flex-wrap items-center gap-2 text-xs">
+                      <div className="flex flex-wrap items-center gap-2 text-xs sm:flex-nowrap">
                         <Badge variant="secondary">{projectEmbed.format}</Badge>
                         <Badge variant="outline">{projectEmbed.status}</Badge>
                         <Badge variant="outline">{projectEmbed.studio}</Badge>
                         <Badge variant="outline">{projectEmbed.episodes}</Badge>
-                        <Button size="sm" className="ml-auto">
-                          Página do projeto
-                        </Button>
                       </div>
                       <Separator />
                       <div className="grid gap-2.5 text-xs text-muted-foreground sm:grid-cols-2">


### PR DESCRIPTION
### Motivation
- Make the project embed more navigable by turning the image and title into link targets that go to the project page and removing the redundant button.
- Improve keyboard/focus accessibility by adding visible focus and hover states to those link targets.
- Preserve the updated embed layout so the image fills the available height and spacing remains consistent.

### Description
- Replaced the image wrapper `div` with an `a` tag linking to `/projeto/sono-bisque-doll` and added `hover`/`focus-visible` styles for border and ring focus states.
- Replaced the `h3` title with an `a` tag linking to the same project URL and added `hover`/`focus-visible` styles for visible focus and color change.
- Removed the `Página do projeto` `Button` and kept the badges and meta grid intact.
- Kept layout adjustments including `sm:items-stretch`, `sm:w-36 sm:self-stretch`, and changed the image to `className="h-full w-full object-cover"` so it fills the card height.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready (server accessible), which succeeded.
- Ran an automated Playwright script that opened `http://127.0.0.1:4173/postagem/teste` and saved a screenshot to `artifacts/postagem-embed-link.png`, which completed successfully.
- Observed a Vite/CSS warning `@import must precede all other statements` during startup, which did not prevent the server from running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e706360b8832583edbb8b576e087d)