### PR TITLE
Make Autocomplete lookup function customizable

### DIFF
--- a/src/lexical-playground/plugins/AutocompletePlugin/index.tsx
+++ b/src/lexical-playground/plugins/AutocompletePlugin/index.tsx
@@ -52,6 +52,10 @@ type SearchPromise = {
 
 export const uuid = createRandomId("autocomplete");
 
+export type AutocompleteSearchFn = (
+  selection: null | BaseSelection,
+) => [boolean, string];
+
 // TODO lookup should be custom
 function $search(selection: null | BaseSelection): [boolean, string] {
   if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
@@ -94,7 +98,11 @@ function formatSuggestionText(suggestion: string): string {
   return `${suggestion} ${isMobile ? "(SWIPE \u2B95)" : "(TAB)"}`;
 }
 
-export default function AutocompletePlugin(): JSX.Element | null {
+export default function AutocompletePlugin({
+  onSearch,
+}: {
+  onSearch?: AutocompleteSearchFn;
+}): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const query = useQuery();
   const { toolbarState } = useToolbarState();
@@ -132,7 +140,9 @@ export default function AutocompletePlugin(): JSX.Element | null {
       }
       editor.update(() => {
         const selection = $getSelection();
-        const [hasMatch, match] = $search(selection);
+        const [hasMatch, match] = onSearch
+          ? onSearch(selection)
+          : $search(selection);
         if (!hasMatch || match !== lastMatch || !$isRangeSelection(selection)) {
           // Outdated
           return;
@@ -163,7 +173,9 @@ export default function AutocompletePlugin(): JSX.Element | null {
     function handleUpdate() {
       editor.update(() => {
         const selection = $getSelection();
-        const [hasMatch, match] = $search(selection);
+        const [hasMatch, match] = onSearch
+          ? onSearch(selection)
+          : $search(selection);
         if (!hasMatch) {
           $clearSuggestion();
           return;
@@ -248,7 +260,7 @@ export default function AutocompletePlugin(): JSX.Element | null {
         : []),
       unmountSuggestion,
     );
-  }, [editor, query, toolbarState.fontSize]);
+  }, [editor, onSearch, query, toolbarState.fontSize]);
 
   return null;
 }


### PR DESCRIPTION
The `AutocompletePlugin` now supports a customizable search lookup function via the `onSearch` prop. This allows users of the plugin to override the default search logic while maintaining the same interface.

Key changes:
- Added `AutocompleteSearchFn` type export.
- Updated `AutocompletePlugin` props to include `onSearch`.
- Integrated `onSearch` into `handleUpdate` and `updateAsyncSuggestion` within the plugin.
- Ensured backward compatibility by falling back to the default `$search` function.

---
*PR created automatically by Jules for task [9088845748703521067](https://jules.google.com/task/9088845748703521067) started by @Gavuriiru*