### PR TITLE
Sanitize dynamic HTML injections

### DIFF
--- a/src/components/lexical/viewer-nodes/ViewerEquationNode.tsx
+++ b/src/components/lexical/viewer-nodes/ViewerEquationNode.tsx
@@ -1,3 +1,4 @@
+import DOMPurify from "dompurify";
 import katex from "katex";
 import {
   $applyNodeReplacement,
@@ -31,7 +32,10 @@ const renderEquationMarkup = (equation: string, inline: boolean) =>
   });
 
 const ViewerEquation = ({ equation, inline }: { equation: string; inline: boolean }) => {
-  const html = React.useMemo(() => renderEquationMarkup(equation, inline), [equation, inline]);
+  const html = React.useMemo(() => {
+    const rawHtml = renderEquationMarkup(equation, inline);
+    return DOMPurify.sanitize(rawHtml, { USE_PROFILES: { html: true, mathMl: true } });
+  }, [equation, inline]);
   const TagName = inline ? "span" : "div";
 
   return <TagName dangerouslySetInnerHTML={{ __html: html }} aria-label="Formula matematica" />;
@@ -105,7 +109,8 @@ export class ViewerEquationNode extends DecoratorNode<JSX.Element> {
     const element = document.createElement(this.__inline ? "span" : "div");
     element.setAttribute("data-lexical-equation", btoa(this.__equation));
     element.setAttribute("data-lexical-inline", String(this.__inline));
-    element.innerHTML = renderEquationMarkup(this.__equation, this.__inline);
+    const rawHtml = renderEquationMarkup(this.__equation, this.__inline);
+    element.innerHTML = DOMPurify.sanitize(rawHtml, { USE_PROFILES: { html: true, mathMl: true } });
     return { element };
   }
 

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -211,12 +211,9 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
     return null;
   }
 
-  return (
-    <style
-      dangerouslySetInnerHTML={{
-        __html: Object.entries(THEMES)
-          .map(
-            ([theme, prefix]) => `
+  const cssStyles = Object.entries(THEMES)
+    .map(
+      ([theme, prefix]) => `
 ${prefix} [data-chart=${id}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
@@ -226,11 +223,10 @@ ${colorConfig
   .join("\n")}
 }
 `,
-          )
-          .join("\n"),
-      }}
-    />
-  );
+    )
+    .join("\n");
+
+  return <style>{cssStyles}</style>;
 };
 
 const ChartTooltip = RechartsPrimitive.Tooltip;


### PR DESCRIPTION
This commit addresses security guidelines regarding `dangerouslySetInnerHTML`. We replaced the risky raw HTML injection for styles in `<ChartContainer />` with standard React children rendering, and properly sanitized the KaTeX formula output using DOMPurify before rendering it via `dangerouslySetInnerHTML`. Per user instruction, existing `.env` variables remained untouched.

---
*PR created automatically by Jules for task [15454566038873731127](https://jules.google.com/task/15454566038873731127) started by @Gavuriiru*