### PR TITLE
🧪 Add tests for getPostStatusLabel

### DIFF
--- a/src/components/dashboard/post-editor/dashboard-posts-types.test.ts
+++ b/src/components/dashboard/post-editor/dashboard-posts-types.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getPostStatusLabel } from "./dashboard-posts-types";
+
+describe("getPostStatusLabel", () => {
+  it("should return 'Publicado' for 'published' status", () => {
+    expect(getPostStatusLabel("published")).toBe("Publicado");
+  });
+
+  it("should return 'Agendado' for 'scheduled' status", () => {
+    expect(getPostStatusLabel("scheduled")).toBe("Agendado");
+  });
+
+  it("should return 'Rascunho' for 'draft' status", () => {
+    expect(getPostStatusLabel("draft")).toBe("Rascunho");
+  });
+
+  it("should return 'Rascunho' for any other status (default case)", () => {
+    // @ts-expect-error - testing invalid status
+    expect(getPostStatusLabel("invalid" as any)).toBe("Rascunho");
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing tests for \`getPostStatusLabel\` in \`dashboard-posts-types.ts\`.
📊 **Coverage:** What scenarios are now tested: 'published', 'scheduled', 'draft', and default case.
✨ **Result:** The improvement in test coverage: Increased reliability of post status label mapping logic.

---
*PR created automatically by Jules for task [3913246879137126361](https://jules.google.com/task/3913246879137126361) started by @Gavuriiru*