### PR TITLE
🎨 Palette: Add ARIA labels to dashboard settings delete buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
+**Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
+**Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.

--- a/src/components/dashboard/settings/DashboardSettingsLayoutTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsLayoutTab.tsx
@@ -152,6 +152,7 @@ export const DashboardSettingsLayoutTab = () => {
                   type="button"
                   size="icon"
                   className={responsiveCompactRowDeleteButtonClass}
+                  aria-label="Remover link da navbar"
                   onClick={() =>
                     setSettings((prev) => ({
                       ...prev,
@@ -251,6 +252,7 @@ export const DashboardSettingsLayoutTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveCompactSelfEndDeleteButtonClass}
+                    aria-label="Remover coluna do footer"
                     onClick={() =>
                       setSettings((prev) => ({
                         ...prev,
@@ -318,6 +320,7 @@ export const DashboardSettingsLayoutTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveCompactRowDeleteButtonClass}
+                        aria-label="Remover link da coluna do footer"
                         onClick={() =>
                           setSettings((prev) => {
                             const nextColumns = [...prev.footer.columns];
@@ -547,6 +550,7 @@ export const DashboardSettingsLayoutTab = () => {
                       type="button"
                       size="icon"
                       className={responsiveCompactRowDeleteButtonClass}
+                      aria-label="Remover parágrafo do aviso legal"
                       onClick={() =>
                         setSettings((prev) => ({
                           ...prev,

--- a/src/components/project-reader/PublicProjectReader.test.tsx
+++ b/src/components/project-reader/PublicProjectReader.test.tsx
@@ -3722,10 +3722,12 @@ describe("PublicProjectReader", () => {
     clickPaginatedTarget({ clientX: 900 });
 
     await waitFor(() => {
-      expect(Number.parseFloat(screen.getByTestId("project-reader-progress-indicator").style.left))
-        .toBeCloseTo(containerLength - indicatorInsetPx, 4);
-      expect(Number.parseFloat(screen.getByTestId("project-reader-progress-label").style.left))
-        .toBeCloseTo(containerLength - labelInsetPx, 4);
+      expect(
+        Number.parseFloat(screen.getByTestId("project-reader-progress-indicator").style.left),
+      ).toBeCloseTo(containerLength - indicatorInsetPx, 4);
+      expect(
+        Number.parseFloat(screen.getByTestId("project-reader-progress-label").style.left),
+      ).toBeCloseTo(containerLength - labelInsetPx, 4);
     });
   });
 
@@ -3750,10 +3752,12 @@ describe("PublicProjectReader", () => {
     goToLastPaginatedPage();
 
     await waitFor(() => {
-      expect(Number.parseFloat(screen.getByTestId("project-reader-progress-indicator").style.left))
-        .toBeCloseTo(indicatorInsetPx, 4);
-      expect(Number.parseFloat(screen.getByTestId("project-reader-progress-label").style.left))
-        .toBeCloseTo(labelInsetPx, 4);
+      expect(
+        Number.parseFloat(screen.getByTestId("project-reader-progress-indicator").style.left),
+      ).toBeCloseTo(indicatorInsetPx, 4);
+      expect(
+        Number.parseFloat(screen.getByTestId("project-reader-progress-label").style.left),
+      ).toBeCloseTo(labelInsetPx, 4);
     });
   });
 

--- a/src/pages/DashboardUsers.owner-governance.test.tsx
+++ b/src/pages/DashboardUsers.owner-governance.test.tsx
@@ -133,7 +133,9 @@ const openNewUserDialog = async () => {
 };
 
 const openUserDialog = async (name: string) => {
-  fireEvent.click(await screen.findByRole("button", { name: new RegExp(`Abrir usuário ${name}`, "i") }));
+  fireEvent.click(
+    await screen.findByRole("button", { name: new RegExp(`Abrir usuário ${name}`, "i") }),
+  );
   return screen.findByRole("dialog", { name: /Editar usuário/i });
 };
 
@@ -165,12 +167,16 @@ describe("DashboardUsers owner governance", () => {
       ownerIds: ["owner-1"],
       handlers: {
         "POST /api/users": ({ options }) =>
-          mockJsonResponse(true, {
-            user: {
-              ...buildUser({ id: "user-2", name: "LuckShiba", order: 1 }),
-              ...(options?.json || {}),
+          mockJsonResponse(
+            true,
+            {
+              user: {
+                ...buildUser({ id: "user-2", name: "LuckShiba", order: 1 }),
+                ...(options?.json || {}),
+              },
             },
-          }, 201),
+            201,
+          ),
         "PUT /api/owners": ({ options }) =>
           mockJsonResponse(true, {
             ownerIds: ["owner-1", "user-2"],
@@ -217,7 +223,9 @@ describe("DashboardUsers owner governance", () => {
         return path === "/api/owners" && method === "PUT";
       });
       expect(ownersCall).toBeTruthy();
-      expect(JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}"))).toEqual({
+      expect(
+        JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}")),
+      ).toEqual({
         ownerIds: ["owner-1", "user-2"],
       });
     });
@@ -286,7 +294,9 @@ describe("DashboardUsers owner governance", () => {
         return path === "/api/owners" && method === "PUT";
       });
       expect(ownersCall).toBeTruthy();
-      expect(JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}"))).toEqual({
+      expect(
+        JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}")),
+      ).toEqual({
         ownerIds: ["owner-1", "user-2"],
       });
     });
@@ -357,7 +367,9 @@ describe("DashboardUsers owner governance", () => {
         return path === "/api/owners" && method === "PUT";
       });
       expect(ownersCall).toBeTruthy();
-      expect(JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}"))).toEqual({
+      expect(
+        JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}")),
+      ).toEqual({
         ownerIds: ["owner-1"],
       });
     });

--- a/src/pages/DashboardUsers.tsx
+++ b/src/pages/DashboardUsers.tsx
@@ -660,22 +660,22 @@ const DashboardUsers = () => {
   const canEditBasicFields = !editingUser
     ? canCreateUsers
     : isEditingSelf ||
-    (actorCanUsersBasic &&
-      (isPrimaryOwnerActor ||
-        (isSecondaryOwnerActor && !isOwnerRecord) ||
-        (isAdminActor && !isOwnerRecord)));
+      (actorCanUsersBasic &&
+        (isPrimaryOwnerActor ||
+          (isSecondaryOwnerActor && !isOwnerRecord) ||
+          (isAdminActor && !isOwnerRecord)));
   const canEditRoles = !editingUser
     ? canCreateUsers
     : actorCanUsersAccess &&
-    (isPrimaryOwnerActor ||
-      (isSecondaryOwnerActor && !isOwnerRecord) ||
-      (isAdminActor && !isOwnerRecord));
+      (isPrimaryOwnerActor ||
+        (isSecondaryOwnerActor && !isOwnerRecord) ||
+        (isAdminActor && !isOwnerRecord));
   const canEditAccessControls = !editingUser
     ? canCreateUsers
     : actorCanUsersAccess &&
-    (isPrimaryOwnerActor ||
-      (isSecondaryOwnerActor && !isOwnerRecord) ||
-      (isAdminActor && !isOwnerRecord));
+      (isPrimaryOwnerActor ||
+        (isSecondaryOwnerActor && !isOwnerRecord) ||
+        (isAdminActor && !isOwnerRecord));
   const canEditStatus = canEditAccessControls && !isEditingSelf && !isPrimaryOwnerRecord;
   const basicProfileOnlyEdit = Boolean(editingUser && canEditBasicFields && !canEditAccessControls);
   const canResetManagedUserTotp = Boolean(
@@ -1048,8 +1048,7 @@ const DashboardUsers = () => {
       return;
     }
     const normalizedPermissions = Array.from(new Set(formState.permissions));
-    const normalizedAccessRole: AccessRole =
-      formState.accessRole === "admin" ? "admin" : "normal";
+    const normalizedAccessRole: AccessRole = formState.accessRole === "admin" ? "admin" : "normal";
     const basePayload = {
       id: formState.id.trim(),
       name: formState.name.trim(),
@@ -1141,10 +1140,10 @@ const DashboardUsers = () => {
         setCurrentUser((prev) =>
           prev
             ? {
-              ...prev,
-              ...data.user,
-              username: prev.username,
-            }
+                ...prev,
+                ...data.user,
+                username: prev.username,
+              }
             : prev,
         );
       }
@@ -1760,8 +1759,9 @@ const DashboardUsers = () => {
       <Dialog open={isDialogOpen} onOpenChange={handleEditorOpenChange} modal={false}>
         {isDialogOpen ? <DashboardEditorBackdrop /> : null}
         <DialogContent
-          className={`project-editor-dialog ${dashboardEditorDialogWidthClassName} gap-0 p-0 ${isEditorDialogScrolled ? "editor-modal-scrolled" : ""
-            }`}
+          className={`project-editor-dialog ${dashboardEditorDialogWidthClassName} gap-0 p-0 ${
+            isEditorDialogScrolled ? "editor-modal-scrolled" : ""
+          }`}
           onPointerDownOutside={(event) => {
             if (isLibraryOpen) {
               event.preventDefault();
@@ -2021,10 +2021,11 @@ const DashboardUsers = () => {
                               <div
                                 key={`${social.label}-${index}`}
                                 data-testid={`user-social-row-${index}`}
-                                className={`overflow-x-auto rounded-xl p-2 ${socialDragOverIndex === index
+                                className={`overflow-x-auto rounded-xl p-2 ${
+                                  socialDragOverIndex === index
                                     ? `${subtleSurfaceClassName} border-primary/40 bg-primary/5`
                                     : subtleSurfaceClassName
-                                  }`}
+                                }`}
                                 onDragOver={(event) => handleSocialDragOver(event, index)}
                                 onDrop={(event) => handleSocialDrop(event, index)}
                               >
@@ -2416,8 +2417,9 @@ const DashboardUsers = () => {
                   <AccordionTrigger className={editorSectionTriggerClassName}>
                     <ProjectEditorAccordionHeader
                       title="Acesso e permissões"
-                      subtitle={`${editorAccessRoleLabel} • ${stripOwnerRole(formState.roles).length
-                        } funções`}
+                      subtitle={`${editorAccessRoleLabel} • ${
+                        stripOwnerRole(formState.roles).length
+                      } funções`}
                     />
                   </AccordionTrigger>
                   <AccordionContent className={editorSectionContentClassName}>
@@ -2468,10 +2470,10 @@ const DashboardUsers = () => {
                                 permissions:
                                   value === "admin"
                                     ? permissionOptions
-                                      .filter((option) =>
-                                        DEFAULT_ADMIN_PERMISSIONS.includes(option.id),
-                                      )
-                                      .map((option) => option.id)
+                                        .filter((option) =>
+                                          DEFAULT_ADMIN_PERMISSIONS.includes(option.id),
+                                        )
+                                        .map((option) => option.id)
                                     : prev.permissions,
                               }))
                             }


### PR DESCRIPTION
**💡 What:** Added `aria-label`s to the icon-only "Trash" buttons used to delete items in the `DashboardSettingsLayoutTab`.
**🎯 Why:** The layout configuration page had multiple list areas (navbar links, footer columns, footer column links, legal text) with icon-only delete buttons. Screen reader users would just hear "button" without knowing its purpose.
**♿ Accessibility:** Improved screen reader accessibility by adding clear, localized (Portuguese) `aria-label`s to the `DashboardActionButton`s containing `Trash2` icons.

---
*PR created automatically by Jules for task [14083717424830281648](https://jules.google.com/task/14083717424830281648) started by @Gavuriiru*