### PR TITLE
⚡ Bolt: Optimize Comments and Project Cards rendering with React.memo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - React.memo for recursive list rendering
+**Learning:** In React, recursive rendering of lists (like nested comment trees) using inline functions (`renderComment`) causes unnecessary re-renders of the entire tree when state changes (like typing in a form input).
+**Action:** Extract recursive render functions into standalone components wrapped in `React.memo`, and ensure props like event handlers are memoized with `useCallback`. This significantly reduces React reconciliation overhead.

--- a/src/components/CommentsSection.tsx
+++ b/src/components/CommentsSection.tsx
@@ -19,7 +19,7 @@ import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
 import { formatDateTime } from "@/lib/date";
 import { MessageSquare, Reply } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
 
 type CommentTargetType = "post" | "project" | "chapter";
@@ -254,9 +254,9 @@ const CommentsSection = ({ targetType, targetId, chapterNumber, volume }: Commen
     }
   };
 
-  const handleDelete = (comment: PublicComment) => {
+  const handleDelete = useCallback((comment: PublicComment) => {
     setDeleteTarget(comment);
-  };
+  }, []);
 
   const handleConfirmDelete = async () => {
     if (!deleteTarget || isDeleting) {
@@ -292,56 +292,6 @@ const CommentsSection = ({ targetType, targetId, chapterNumber, volume }: Commen
       setIsDeleting(false);
     }
   };
-
-  const renderComment = (comment: CommentNode, depth = 0) => (
-    <div
-      key={comment.id}
-      id={`comment-${comment.id}`}
-      className={depth > 0 ? "pl-6 border-l border-border/40" : ""}
-    >
-      <div className="flex gap-3">
-        <Avatar className="h-10 w-10">
-          {comment.avatarUrl ? <AvatarImage src={comment.avatarUrl} alt={comment.name} /> : null}
-          <AvatarFallback>{initialsFromName(comment.name)}</AvatarFallback>
-        </Avatar>
-        <div className="flex-1 space-y-1">
-          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-            <span className="text-sm font-semibold text-foreground">{comment.name}</span>
-            <span>{formatDateTime(comment.createdAt)}</span>
-          </div>
-          <p className="text-sm text-muted-foreground whitespace-pre-line">{comment.content}</p>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-auto px-2 text-xs"
-              onClick={() => setReplyTo(comment)}
-            >
-              <Reply className="mr-1 h-3 w-3" />
-              Responder
-            </Button>
-            {canModerate ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-auto px-2 text-xs text-red-400"
-                onClick={() => handleDelete(comment)}
-              >
-                Excluir
-              </Button>
-            ) : null}
-          </div>
-        </div>
-      </div>
-      {comment.replies.length > 0 ? (
-        <div className="mt-4 space-y-4">
-          {comment.replies.map((reply) => renderComment(reply, depth + 1))}
-        </div>
-      ) : null}
-    </div>
-  );
 
   return (
     <>
@@ -422,7 +372,18 @@ const CommentsSection = ({ targetType, targetId, chapterNumber, volume }: Commen
               Ainda não há comentários aprovados.
             </div>
           ) : (
-            <div className="space-y-6">{commentTree.map((comment) => renderComment(comment))}</div>
+            <div className="space-y-6">
+              {commentTree.map((comment) => (
+                <CommentItem
+                  key={comment.id}
+                  comment={comment}
+                  depth={0}
+                  canModerate={canModerate}
+                  setReplyTo={setReplyTo}
+                  handleDelete={handleDelete}
+                />
+              ))}
+            </div>
           )}
         </CardContent>
       </Card>
@@ -459,5 +420,76 @@ const CommentsSection = ({ targetType, targetId, chapterNumber, volume }: Commen
     </>
   );
 };
+
+type CommentItemProps = {
+  comment: CommentNode;
+  depth: number;
+  canModerate: boolean;
+  setReplyTo: (comment: PublicComment) => void;
+  handleDelete: (comment: PublicComment) => void;
+};
+
+const CommentItem = memo(
+  ({ comment, depth, canModerate, setReplyTo, handleDelete }: CommentItemProps) => {
+    return (
+      <div
+        id={`comment-${comment.id}`}
+        className={depth > 0 ? "pl-6 border-l border-border/40" : ""}
+      >
+        <div className="flex gap-3">
+          <Avatar className="h-10 w-10">
+            {comment.avatarUrl ? <AvatarImage src={comment.avatarUrl} alt={comment.name} /> : null}
+            <AvatarFallback>{initialsFromName(comment.name)}</AvatarFallback>
+          </Avatar>
+          <div className="flex-1 space-y-1">
+            <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+              <span className="text-sm font-semibold text-foreground">{comment.name}</span>
+              <span>{formatDateTime(comment.createdAt)}</span>
+            </div>
+            <p className="text-sm text-muted-foreground whitespace-pre-line">{comment.content}</p>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-auto px-2 text-xs"
+                onClick={() => setReplyTo(comment)}
+              >
+                <Reply className="mr-1 h-3 w-3" />
+                Responder
+              </Button>
+              {canModerate ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto px-2 text-xs text-red-400"
+                  onClick={() => handleDelete(comment)}
+                >
+                  Excluir
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+        {comment.replies.length > 0 ? (
+          <div className="mt-4 space-y-4">
+            {comment.replies.map((reply) => (
+              <CommentItem
+                key={reply.id}
+                comment={reply}
+                depth={depth + 1}
+                canModerate={canModerate}
+                setReplyTo={setReplyTo}
+                handleDelete={handleDelete}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+CommentItem.displayName = "CommentItem";
 
 export default CommentsSection;

--- a/src/components/project-reader/PublicProjectReader.test.tsx
+++ b/src/components/project-reader/PublicProjectReader.test.tsx
@@ -3722,10 +3722,12 @@ describe("PublicProjectReader", () => {
     clickPaginatedTarget({ clientX: 900 });
 
     await waitFor(() => {
-      expect(Number.parseFloat(screen.getByTestId("project-reader-progress-indicator").style.left))
-        .toBeCloseTo(containerLength - indicatorInsetPx, 4);
-      expect(Number.parseFloat(screen.getByTestId("project-reader-progress-label").style.left))
-        .toBeCloseTo(containerLength - labelInsetPx, 4);
+      expect(
+        Number.parseFloat(screen.getByTestId("project-reader-progress-indicator").style.left),
+      ).toBeCloseTo(containerLength - indicatorInsetPx, 4);
+      expect(
+        Number.parseFloat(screen.getByTestId("project-reader-progress-label").style.left),
+      ).toBeCloseTo(containerLength - labelInsetPx, 4);
     });
   });
 
@@ -3750,10 +3752,12 @@ describe("PublicProjectReader", () => {
     goToLastPaginatedPage();
 
     await waitFor(() => {
-      expect(Number.parseFloat(screen.getByTestId("project-reader-progress-indicator").style.left))
-        .toBeCloseTo(indicatorInsetPx, 4);
-      expect(Number.parseFloat(screen.getByTestId("project-reader-progress-label").style.left))
-        .toBeCloseTo(labelInsetPx, 4);
+      expect(
+        Number.parseFloat(screen.getByTestId("project-reader-progress-indicator").style.left),
+      ).toBeCloseTo(indicatorInsetPx, 4);
+      expect(
+        Number.parseFloat(screen.getByTestId("project-reader-progress-label").style.left),
+      ).toBeCloseTo(labelInsetPx, 4);
     });
   });
 

--- a/src/components/project/PublicProjectCard.tsx
+++ b/src/components/project/PublicProjectCard.tsx
@@ -1,5 +1,5 @@
 import { Eye, Hash } from "lucide-react";
-import type { CSSProperties, MouseEvent, Ref } from "react";
+import { memo, type CSSProperties, type MouseEvent, type Ref } from "react";
 import { Link } from "react-router-dom";
 
 import PublicInteractiveCardShell from "@/components/PublicInteractiveCardShell";
@@ -752,4 +752,4 @@ const PublicProjectCard = ({
   );
 };
 
-export default PublicProjectCard;
+export default memo(PublicProjectCard);

--- a/src/pages/DashboardUsers.owner-governance.test.tsx
+++ b/src/pages/DashboardUsers.owner-governance.test.tsx
@@ -133,7 +133,9 @@ const openNewUserDialog = async () => {
 };
 
 const openUserDialog = async (name: string) => {
-  fireEvent.click(await screen.findByRole("button", { name: new RegExp(`Abrir usuário ${name}`, "i") }));
+  fireEvent.click(
+    await screen.findByRole("button", { name: new RegExp(`Abrir usuário ${name}`, "i") }),
+  );
   return screen.findByRole("dialog", { name: /Editar usuário/i });
 };
 
@@ -165,12 +167,16 @@ describe("DashboardUsers owner governance", () => {
       ownerIds: ["owner-1"],
       handlers: {
         "POST /api/users": ({ options }) =>
-          mockJsonResponse(true, {
-            user: {
-              ...buildUser({ id: "user-2", name: "LuckShiba", order: 1 }),
-              ...(options?.json || {}),
+          mockJsonResponse(
+            true,
+            {
+              user: {
+                ...buildUser({ id: "user-2", name: "LuckShiba", order: 1 }),
+                ...(options?.json || {}),
+              },
             },
-          }, 201),
+            201,
+          ),
         "PUT /api/owners": ({ options }) =>
           mockJsonResponse(true, {
             ownerIds: ["owner-1", "user-2"],
@@ -217,7 +223,9 @@ describe("DashboardUsers owner governance", () => {
         return path === "/api/owners" && method === "PUT";
       });
       expect(ownersCall).toBeTruthy();
-      expect(JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}"))).toEqual({
+      expect(
+        JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}")),
+      ).toEqual({
         ownerIds: ["owner-1", "user-2"],
       });
     });
@@ -286,7 +294,9 @@ describe("DashboardUsers owner governance", () => {
         return path === "/api/owners" && method === "PUT";
       });
       expect(ownersCall).toBeTruthy();
-      expect(JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}"))).toEqual({
+      expect(
+        JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}")),
+      ).toEqual({
         ownerIds: ["owner-1", "user-2"],
       });
     });
@@ -357,7 +367,9 @@ describe("DashboardUsers owner governance", () => {
         return path === "/api/owners" && method === "PUT";
       });
       expect(ownersCall).toBeTruthy();
-      expect(JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}"))).toEqual({
+      expect(
+        JSON.parse(String((ownersCall?.[2] as RequestInit | undefined)?.body || "{}")),
+      ).toEqual({
         ownerIds: ["owner-1"],
       });
     });

--- a/src/pages/DashboardUsers.tsx
+++ b/src/pages/DashboardUsers.tsx
@@ -660,22 +660,22 @@ const DashboardUsers = () => {
   const canEditBasicFields = !editingUser
     ? canCreateUsers
     : isEditingSelf ||
-    (actorCanUsersBasic &&
-      (isPrimaryOwnerActor ||
-        (isSecondaryOwnerActor && !isOwnerRecord) ||
-        (isAdminActor && !isOwnerRecord)));
+      (actorCanUsersBasic &&
+        (isPrimaryOwnerActor ||
+          (isSecondaryOwnerActor && !isOwnerRecord) ||
+          (isAdminActor && !isOwnerRecord)));
   const canEditRoles = !editingUser
     ? canCreateUsers
     : actorCanUsersAccess &&
-    (isPrimaryOwnerActor ||
-      (isSecondaryOwnerActor && !isOwnerRecord) ||
-      (isAdminActor && !isOwnerRecord));
+      (isPrimaryOwnerActor ||
+        (isSecondaryOwnerActor && !isOwnerRecord) ||
+        (isAdminActor && !isOwnerRecord));
   const canEditAccessControls = !editingUser
     ? canCreateUsers
     : actorCanUsersAccess &&
-    (isPrimaryOwnerActor ||
-      (isSecondaryOwnerActor && !isOwnerRecord) ||
-      (isAdminActor && !isOwnerRecord));
+      (isPrimaryOwnerActor ||
+        (isSecondaryOwnerActor && !isOwnerRecord) ||
+        (isAdminActor && !isOwnerRecord));
   const canEditStatus = canEditAccessControls && !isEditingSelf && !isPrimaryOwnerRecord;
   const basicProfileOnlyEdit = Boolean(editingUser && canEditBasicFields && !canEditAccessControls);
   const canResetManagedUserTotp = Boolean(
@@ -1048,8 +1048,7 @@ const DashboardUsers = () => {
       return;
     }
     const normalizedPermissions = Array.from(new Set(formState.permissions));
-    const normalizedAccessRole: AccessRole =
-      formState.accessRole === "admin" ? "admin" : "normal";
+    const normalizedAccessRole: AccessRole = formState.accessRole === "admin" ? "admin" : "normal";
     const basePayload = {
       id: formState.id.trim(),
       name: formState.name.trim(),
@@ -1141,10 +1140,10 @@ const DashboardUsers = () => {
         setCurrentUser((prev) =>
           prev
             ? {
-              ...prev,
-              ...data.user,
-              username: prev.username,
-            }
+                ...prev,
+                ...data.user,
+                username: prev.username,
+              }
             : prev,
         );
       }
@@ -1760,8 +1759,9 @@ const DashboardUsers = () => {
       <Dialog open={isDialogOpen} onOpenChange={handleEditorOpenChange} modal={false}>
         {isDialogOpen ? <DashboardEditorBackdrop /> : null}
         <DialogContent
-          className={`project-editor-dialog ${dashboardEditorDialogWidthClassName} gap-0 p-0 ${isEditorDialogScrolled ? "editor-modal-scrolled" : ""
-            }`}
+          className={`project-editor-dialog ${dashboardEditorDialogWidthClassName} gap-0 p-0 ${
+            isEditorDialogScrolled ? "editor-modal-scrolled" : ""
+          }`}
           onPointerDownOutside={(event) => {
             if (isLibraryOpen) {
               event.preventDefault();
@@ -2021,10 +2021,11 @@ const DashboardUsers = () => {
                               <div
                                 key={`${social.label}-${index}`}
                                 data-testid={`user-social-row-${index}`}
-                                className={`overflow-x-auto rounded-xl p-2 ${socialDragOverIndex === index
+                                className={`overflow-x-auto rounded-xl p-2 ${
+                                  socialDragOverIndex === index
                                     ? `${subtleSurfaceClassName} border-primary/40 bg-primary/5`
                                     : subtleSurfaceClassName
-                                  }`}
+                                }`}
                                 onDragOver={(event) => handleSocialDragOver(event, index)}
                                 onDrop={(event) => handleSocialDrop(event, index)}
                               >
@@ -2416,8 +2417,9 @@ const DashboardUsers = () => {
                   <AccordionTrigger className={editorSectionTriggerClassName}>
                     <ProjectEditorAccordionHeader
                       title="Acesso e permissões"
-                      subtitle={`${editorAccessRoleLabel} • ${stripOwnerRole(formState.roles).length
-                        } funções`}
+                      subtitle={`${editorAccessRoleLabel} • ${
+                        stripOwnerRole(formState.roles).length
+                      } funções`}
                     />
                   </AccordionTrigger>
                   <AccordionContent className={editorSectionContentClassName}>
@@ -2468,10 +2470,10 @@ const DashboardUsers = () => {
                                 permissions:
                                   value === "admin"
                                     ? permissionOptions
-                                      .filter((option) =>
-                                        DEFAULT_ADMIN_PERMISSIONS.includes(option.id),
-                                      )
-                                      .map((option) => option.id)
+                                        .filter((option) =>
+                                          DEFAULT_ADMIN_PERMISSIONS.includes(option.id),
+                                        )
+                                        .map((option) => option.id)
                                     : prev.permissions,
                               }))
                             }


### PR DESCRIPTION
💡 What: Extracted `renderComment` into a `React.memo`-wrapped `CommentItem` and wrapped `PublicProjectCard` with `React.memo`.
🎯 Why: Typing in the comment form caused the entire comment tree to re-render. Similarly, filtering projects caused all project cards to re-render unnecessarily.
📊 Impact: Expected to significantly reduce React reconciliations, particularly on pages with large comment threads or large project grids.
🔬 Measurement: Verify using React DevTools Profiler by typing in the comment box or changing project filters and observing the reduced component re-render times.

---
*PR created automatically by Jules for task [11818191353192281587](https://jules.google.com/task/11818191353192281587) started by @Gavuriiru*