### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to LexicalToolbar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+## 2026-04-23 - Added titles and aria labels to Lexical Toolbar
+**Learning:** Icon-only formatting buttons in text editors are a common accessibility oversight. They need both `title` for native hover tooltips and `aria-label` for screen readers. Using Portuguese labels is consistent with the app's default locale.
+**Action:** When working with text editors or toolbars with icon buttons, always ensure proper native tooltip () and screen reader () attributes are present, verifying the correct application language.
+## 2024-05-18 - Added titles and aria labels to Lexical Toolbar
+**Learning:** Icon-only formatting buttons in text editors are a common accessibility oversight. They need both `title` for native hover tooltips and `aria-label` for screen readers. Using Portuguese labels is consistent with the app locale.
+**Action:** When working with text editors or toolbars with icon buttons, always ensure proper native tooltip (`title`) and screen reader (`aria-label`) attributes are present, verifying the correct application language.

--- a/src/components/lexical/LexicalToolbar.tsx
+++ b/src/components/lexical/LexicalToolbar.tsx
@@ -227,6 +227,8 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, "bold")}
+          title="Negrito"
+          aria-label="Negrito"
         >
           <Bold className="h-4 w-4" />
         </Button>
@@ -235,6 +237,8 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, "italic")}
+          title="Itálico"
+          aria-label="Itálico"
         >
           <Italic className="h-4 w-4" />
         </Button>
@@ -243,6 +247,8 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, "underline")}
+          title="Sublinhado"
+          aria-label="Sublinhado"
         >
           <Underline className="h-4 w-4" />
         </Button>
@@ -251,6 +257,8 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, "strikethrough")}
+          title="Tachado"
+          aria-label="Tachado"
         >
           <Strikethrough className="h-4 w-4" />
         </Button>
@@ -259,6 +267,8 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, "left")}
+          title="Alinhar à esquerda"
+          aria-label="Alinhar à esquerda"
         >
           <AlignLeft className="h-4 w-4" />
         </Button>
@@ -267,6 +277,8 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, "center")}
+          title="Centralizar"
+          aria-label="Centralizar"
         >
           <AlignCenter className="h-4 w-4" />
         </Button>
@@ -275,6 +287,8 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, "right")}
+          title="Alinhar à direita"
+          aria-label="Alinhar à direita"
         >
           <AlignRight className="h-4 w-4" />
         </Button>
@@ -283,6 +297,8 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => requireSelection(INSERT_UNORDERED_LIST_COMMAND)}
+          title="Lista com marcadores"
+          aria-label="Lista com marcadores"
         >
           <List className="h-4 w-4" />
         </Button>
@@ -291,19 +307,49 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => requireSelection(INSERT_ORDERED_LIST_COMMAND)}
+          title="Lista numerada"
+          aria-label="Lista numerada"
         >
           <ListOrdered className="h-4 w-4" />
         </Button>
-        <Button type="button" variant="ghost" size="icon" onClick={() => onRequestLink?.()}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => onRequestLink?.()}
+          title="Inserir link"
+          aria-label="Inserir link"
+        >
           <Link2 className="h-4 w-4" />
         </Button>
-        <Button type="button" variant="ghost" size="icon" onClick={() => onRequestImage?.()}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => onRequestImage?.()}
+          title="Inserir imagem"
+          aria-label="Inserir imagem"
+        >
           <ImageIcon className="h-4 w-4" />
         </Button>
-        <Button type="button" variant="ghost" size="icon" onClick={() => onRequestVideo?.()}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => onRequestVideo?.()}
+          title="Inserir vídeo"
+          aria-label="Inserir vídeo"
+        >
           <Video className="h-4 w-4" />
         </Button>
-        <Button type="button" variant="ghost" size="icon" onClick={() => onRequestTable?.()}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => onRequestTable?.()}
+          title="Inserir tabela"
+          aria-label="Inserir tabela"
+        >
           <Table className="h-4 w-4" />
         </Button>
         <Button
@@ -311,6 +357,8 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => editor.dispatchCommand(UNDO_COMMAND, undefined)}
+          title="Desfazer"
+          aria-label="Desfazer"
         >
           <Undo2 className="h-4 w-4" />
         </Button>
@@ -319,6 +367,8 @@ const LexicalToolbar = ({
           variant="ghost"
           size="icon"
           onClick={() => editor.dispatchCommand(REDO_COMMAND, undefined)}
+          title="Refazer"
+          aria-label="Refazer"
         >
           <Redo2 className="h-4 w-4" />
         </Button>


### PR DESCRIPTION
💡 What: Added `title` and `aria-label` attributes to the 15 icon-only buttons in the Lexical editor toolbar (formatting, alignment, lists, inserts, and history).
🎯 Why: Without text labels, icon-only buttons are completely inaccessible to screen reader users and can be confusing for sighted users who don't recognize the icons.
♿ Accessibility: Provides an accessible name for screen readers via `aria-label` and native hover tooltips for visual users via `title`. Translated to Portuguese to match the app's default language.

---
*PR created automatically by Jules for task [12983097827872040203](https://jules.google.com/task/12983097827872040203) started by @Gavuriiru*