### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Lexical Playground innerHTML sinks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Server-Side Request Forgery (SSRF) when proxying external artwork and background assets (`server/lib/project-og-assets.js` and `server/lib/institutional-og.js`) using `fetch()`.
 **Learning:** Functions designed to proxy external imagery were directly passing user-supplied strings or configurable external URLs to `fetch()` without strictly parsing via the `URL` constructor or blocking redirects. This could allow an attacker to make the server fetch `file://` (if node-fetch supports it, though built-in fetch might fail, but it's risky) or internal IP address endpoints (`http://169.254.169.254/...`).
 **Prevention:** Always parse external proxy targets with the `URL` constructor, enforce `https:` or `http:` protocol, and configure the fetch client to block redirects (e.g., `redirect: 'error'`) to prevent attackers from bypassing initial checks via redirecting to internal hosts.
+## 2025-04-20 - [XSS] Unsanitized HTML string injection in Lexical Playground DOM sinks
+
+**Vulnerability:** Raw HTML strings were assigned to `innerHTML` sinks without sanitization within `src/lexical-playground/nodes/ImageNode.tsx` and `src/lexical-playground/hooks/useReport.ts`.
+**Learning:** Even within an encapsulated rich-text editor setup or helper hooks, directly passing HTML strings to `innerHTML` exposes an XSS risk if those strings can be populated with user content.
+**Prevention:** Always sanitize strings with `DOMPurify.sanitize` (using strict profiles like `{ USE_PROFILES: { html: true } }` where appropriate) before rendering them via `innerHTML` or `dangerouslySetInnerHTML`.

--- a/src/lexical-playground/hooks/useReport.ts
+++ b/src/lexical-playground/hooks/useReport.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import DOMPurify from "dompurify";
 import { useCallback, useEffect, useRef } from "react";
 
 const getElement = (): HTMLElement => {
@@ -58,7 +59,9 @@ export default function useReport(): (
       if (timer.current !== null) {
         clearTimeout(timer.current);
       }
-      element.innerHTML = content;
+      element.innerHTML = DOMPurify.sanitize(content, {
+        USE_PROFILES: { html: true },
+      });
       timer.current = setTimeout(cleanup, 1000);
       return timer.current;
     },

--- a/src/lexical-playground/nodes/ImageNode.tsx
+++ b/src/lexical-playground/nodes/ImageNode.tsx
@@ -47,6 +47,7 @@ import {
 } from "lexical";
 import * as React from "react";
 
+import DOMPurify from "dompurify";
 import { EmojiNode } from "./EmojiNode";
 import { KeywordNode } from "./KeywordNode";
 
@@ -199,7 +200,9 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
       if (captionHtml) {
         const figureElement = document.createElement("figure");
         const figcaptionElement = document.createElement("figcaption");
-        figcaptionElement.innerHTML = captionHtml;
+        figcaptionElement.innerHTML = DOMPurify.sanitize(captionHtml, {
+          USE_PROFILES: { html: true },
+        });
 
         figureElement.appendChild(imgElement);
         figureElement.appendChild(figcaptionElement);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Raw HTML strings were assigned to `innerHTML` sinks without sanitization within `src/lexical-playground/nodes/ImageNode.tsx` and `src/lexical-playground/hooks/useReport.ts`.
🎯 Impact: This exposes an XSS risk if those strings can be populated with user content, leading to arbitrary JavaScript execution.
🔧 Fix: Sanitized the input using `DOMPurify.sanitize(..., { USE_PROFILES: { html: true } })` before assigning to `innerHTML`. Also added a note to `.jules/sentinel.md`.
✅ Verification: Ran `npm run lint` and `npm run test` to verify changes, no regressions were found. DOMPurify is already a registered dependency in this repository.

---
*PR created automatically by Jules for task [11549125580194539837](https://jules.google.com/task/11549125580194539837) started by @Gavuriiru*