### PR TITLE
🎨 Palette: Add ARIA labels to PostContentEditor toolbar buttons

### DIFF
--- a/src/components/PostContentEditor.tsx
+++ b/src/components/PostContentEditor.tsx
@@ -144,7 +144,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => onApplyWrap("**")}
-                title="Negrito"
+                title="Negrito" aria-label="Negrito"
               >
                 <Bold className="h-4 w-4" />
               </Button>
@@ -153,7 +153,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => onApplyWrap("*")}
-                title="Itálico"
+                title="Itálico" aria-label="Itálico"
               >
                 <Italic className="h-4 w-4" />
               </Button>
@@ -162,7 +162,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => onApplyWrap("<u>", "</u>")}
-                title="Sublinhado"
+                title="Sublinhado" aria-label="Sublinhado"
               >
                 <Underline className="h-4 w-4" />
               </Button>
@@ -171,7 +171,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => onApplyWrap("~~")}
-                title="Tachado"
+                title="Tachado" aria-label="Tachado"
               >
                 <Strikethrough className="h-4 w-4" />
               </Button>
@@ -180,7 +180,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={onApplyHeading}
-                title="Título"
+                title="Título" aria-label="Título"
               >
                 <Heading1 className="h-4 w-4" />
               </Button>
@@ -189,7 +189,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={onApplyUnorderedList}
-                title="Lista"
+                title="Lista" aria-label="Lista"
               >
                 <List className="h-4 w-4" />
               </Button>
@@ -198,7 +198,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={onApplyOrderedList}
-                title="Lista numerada"
+                title="Lista numerada" aria-label="Lista numerada"
               >
                 <ListOrdered className="h-4 w-4" />
               </Button>
@@ -207,7 +207,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => onAlign("left")}
-                title="Alinhar à esquerda"
+                title="Alinhar à esquerda" aria-label="Alinhar à esquerda"
               >
                 <AlignLeft className="h-4 w-4" />
               </Button>
@@ -216,7 +216,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => onAlign("center")}
-                title="Centralizar"
+                title="Centralizar" aria-label="Centralizar"
               >
                 <AlignCenter className="h-4 w-4" />
               </Button>
@@ -225,7 +225,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => onAlign("right")}
-                title="Alinhar à direita"
+                title="Alinhar à direita" aria-label="Alinhar à direita"
               >
                 <AlignRight className="h-4 w-4" />
               </Button>
@@ -325,7 +325,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={onOpenImageDialog}
-                title="Imagem"
+                title="Imagem" aria-label="Imagem"
               >
                 <FileImage className="h-4 w-4" />
               </Button>
@@ -334,7 +334,7 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={onOpenLinkDialog}
-                title="Inserir link"
+                title="Inserir link" aria-label="Inserir link"
               >
                 <LinkIcon className="h-4 w-4" />
               </Button>
@@ -343,14 +343,14 @@ const PostContentEditor = ({
                 variant="ghost"
                 size="icon"
                 onClick={onEmbedVideo}
-                title="Incorporar vídeo"
+                title="Incorporar vídeo" aria-label="Incorporar vídeo"
               >
                 <Video className="h-4 w-4" />
               </Button>
-              <Button type="button" variant="ghost" size="icon" onClick={onUndo} title="Desfazer">
+              <Button type="button" variant="ghost" size="icon" onClick={onUndo} title="Desfazer" aria-label="Desfazer">
                 <Undo2 className="h-4 w-4" />
               </Button>
-              <Button type="button" variant="ghost" size="icon" onClick={onRedo} title="Refazer">
+              <Button type="button" variant="ghost" size="icon" onClick={onRedo} title="Refazer" aria-label="Refazer">
                 <Redo2 className="h-4 w-4" />
               </Button>
               {toolbarExtra}


### PR DESCRIPTION
💡 What: The UX enhancement added: `aria-label`s to the toolbar buttons in `PostContentEditor` 
🎯 Why: The user problem it solves: The buttons were icon-only and didn't have accessible labels for screen readers.
📸 Before/After: Before, buttons only had `title`. After, they have both `title` and `aria-label` which improves accessibility.
♿ Accessibility: Any a11y improvements made: Added `aria-label` matching the existing `title` values to toolbar action buttons.

---
*PR created automatically by Jules for task [3539295725542810616](https://jules.google.com/task/3539295725542810616) started by @Gavuriiru*