### PR TITLE
🎨 Palette: Add ARIA label to gradient button

### DIFF
--- a/src/components/PostContentEditor.tsx
+++ b/src/components/PostContentEditor.tsx
@@ -270,6 +270,7 @@ const PostContentEditor = ({
                     variant="outline"
                     size="icon"
                     title="Gradiente"
+                    aria-label="Gradiente"
                     className="border-border/60 bg-linear-to-br from-primary/20 via-background to-accent/20 text-primary hover:border-primary/60"
                   >
                     <Palette className="h-4 w-4" />


### PR DESCRIPTION
💡 **What:** Added an `aria-label="Gradiente"` attribute to the icon-only Gradient tool button in the Post Content Editor toolbar.
🎯 **Why:** To ensure that screen reader users can correctly identify the purpose of this button. The button only contained a visual icon (`<Palette />`) and a `title`, which is not always reliably read by assistive technologies.
📸 **Before/After:** No visual change.
♿ **Accessibility:** This directly improves keyboard/screen reader accessibility by providing a clear text alternative for an icon-only interactive element, consistent with the rest of the toolbar buttons.

---
*PR created automatically by Jules for task [11589965722509380335](https://jules.google.com/task/11589965722509380335) started by @Gavuriiru*