### PR TITLE
🎨 Palette: [UX improvement] Add aria-labels to dashboard widget reorder buttons

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1407,6 +1407,7 @@ const Dashboard = () => {
                     <DashboardActionButton
                       type="button"
                       size="icon"
+                      aria-label="Mover widget para cima"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
                     >
@@ -1415,6 +1416,7 @@ const Dashboard = () => {
                     <DashboardActionButton
                       type="button"
                       size="icon"
+                      aria-label="Mover widget para baixo"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
                     >


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only buttons responsible for moving dashboard widgets up and down.
🎯 Why: To improve screen reader accessibility, as the buttons only contained visual icons (`ArrowUp` and `ArrowDown`) without any text content or accessible names.
📸 Before/After: Visual presentation remains exactly the same; the change is purely semantic for assistive technologies.
♿ Accessibility: Improved screen reader support for the widget reordering controls by providing the accessible names "Mover widget para cima" and "Mover widget para baixo".

---
*PR created automatically by Jules for task [3482353925577916862](https://jules.google.com/task/3482353925577916862) started by @Gavuriiru*