### PR TITLE
🎨 Palette: Add missing ARIA labels to Trash buttons in Dashboard Pages

### DIFF
--- a/src/pages/DashboardPages.tsx
+++ b/src/pages/DashboardPages.tsx
@@ -1423,6 +1423,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                     <Button
                                       variant="ghost"
                                       size="icon"
+                                      aria-label={`Remover badge ${index + 1}`}
                                       onClick={() => {
                                         const next = pages.about.heroBadges.filter(
                                           (_, i) => i !== index,
@@ -1516,6 +1517,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                       <Button
                                         variant="ghost"
                                         size="icon"
+                                        aria-label={`Remover destaque ${index + 1}`}
                                         onClick={() =>
                                           updateAbout({
                                             highlights: pages.about.highlights.filter(
@@ -1611,6 +1613,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                   <Button
                                     variant="ghost"
                                     size="icon"
+                                    aria-label={`Remover parágrafo ${index + 1}`}
                                     onClick={() => {
                                       const next = pages.about.manifestoParagraphs.filter(
                                         (_, i) => i !== index,
@@ -1705,6 +1708,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                       <Button
                                         variant="ghost"
                                         size="icon"
+                                        aria-label={`Remover pilar ${index + 1}`}
                                         onClick={() =>
                                           updateAbout({
                                             pillars: pages.about.pillars.filter(
@@ -1826,6 +1830,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                       <Button
                                         variant="ghost"
                                         size="icon"
+                                        aria-label={`Remover valor ${index + 1}`}
                                         onClick={() =>
                                           updateAbout({
                                             values: pages.about.values.filter(
@@ -1979,6 +1984,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                       <Button
                                         variant="ghost"
                                         size="icon"
+                                        aria-label={`Remover custo ${index + 1}`}
                                         onClick={() =>
                                           updateDonations({
                                             costs: pages.donations.costs.filter(
@@ -2574,6 +2580,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                       <Button
                                         variant="ghost"
                                         size="icon"
+                                        aria-label={`Remover doador ${index + 1}`}
                                         onClick={() =>
                                           updateDonations({
                                             donors: pages.donations.donors.filter(
@@ -2733,6 +2740,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                       <Button
                                         variant="ghost"
                                         size="icon"
+                                        aria-label={`Remover cartão de introdução ${index + 1}`}
                                         onClick={() =>
                                           updateFaq({
                                             introCards: pages.faq.introCards.filter(
@@ -2862,6 +2870,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                       <Button
                                         variant="ghost"
                                         size="icon"
+                                        aria-label={`Remover grupo de dúvidas ${groupIndex + 1}`}
                                         onClick={() =>
                                           updateFaq({
                                             groups: pages.faq.groups.filter(
@@ -2982,6 +2991,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                               <Button
                                                 variant="ghost"
                                                 size="icon"
+                                                aria-label={`Remover pergunta ${itemIndex + 1}`}
                                                 onClick={() => {
                                                   const next = [...pages.faq.groups];
                                                   const items = group.items.filter(
@@ -3205,6 +3215,7 @@ const DashboardPagesContent = ({ currentUser }: DashboardPagesContentProps) => {
                                       <Button
                                         variant="ghost"
                                         size="icon"
+                                        aria-label={`Remover cargo ${index + 1}`}
                                         onClick={() =>
                                           updateRecruitment({
                                             roles: pages.recruitment.roles.filter(


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to 11 icon-only "Trash/Delete" buttons found within dynamically mapped arrays (e.g., FAQ questions, donation costs, recruitment roles) inside the `DashboardPages.tsx` form interface.
🎯 **Why**: When visually impaired users navigated through complex settings like the About page or FAQ, they encountered multiple identical "unlabeled button" elements without context on what entity they were deleting, making the interface inaccessible for screen readers.
📸 **Before/After**: Visually identical. Under the hood:
```tsx
// Before
<Button variant="ghost" size="icon" onClick={...}>
  <Trash2 className="h-4 w-4" />
</Button>

// After
<Button variant="ghost" size="icon" aria-label={`Remover cargo ${index + 1}`} onClick={...}>
  <Trash2 className="h-4 w-4" />
</Button>
```
♿ **Accessibility**: Enhanced keyboard navigation and screen reader support (WCAG 4.1.2 Name, Role, Value) by clearly describing the action and targeting context of icon-only delete buttons in variable-length form arrays. The labels are in Portuguese (e.g. "Remover pergunta 1", "Remover cargo 2") conforming to app localization.

---
*PR created automatically by Jules for task [13048630948139264877](https://jules.google.com/task/13048630948139264877) started by @Gavuriiru*