### PR TITLE
🎨 Palette: Add ARIA labels to dashboard icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2026-05-13 - Adding ARIA Labels to Icon-Only Buttons
+**Learning:** Icon-only buttons (like `DashboardActionButton` wrapping `Lucide` icons) throughout the app lack accessible names. Additionally, the dashboard is entirely in Portuguese, so even if the underlying code is English, ARIA labels must be added in Portuguese to match the user's expected language profile. Also, using `pnpm i` in the sandbox alters thousands of lines in `pnpm-lock.yaml`, requiring a `git restore` to avoid breaking the < 50 line boundary rule.
+**Action:** Always manually add `aria-label` in Portuguese to icon-only buttons, add `aria-hidden="true"` to the nested SVG icon, and be mindful of restoring `pnpm-lock.yaml` after environment setups.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1409,16 +1409,18 @@ const Dashboard = () => {
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
+                      aria-label="Mover widget para cima"
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
+                      aria-label="Mover widget para baixo"
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"

--- a/src/pages/DashboardPosts.tsx
+++ b/src/pages/DashboardPosts.tsx
@@ -2124,7 +2124,12 @@ const DashboardPosts = () => {
                             </DashboardActionButton>
                           ) : null}
                           {editorPublicHref ? (
-                            <DashboardActionButton type="button" size="icon" asChild>
+                            <DashboardActionButton
+                              type="button"
+                              size="icon"
+                              asChild
+                              aria-label="Visualizar postagem"
+                            >
                               <Link target="_blank" rel="noreferrer" to={editorPublicHref}>
                                 <Eye className="h-4 w-4" aria-hidden="true" />
                               </Link>

--- a/src/pages/DashboardProjectsEditor.tsx
+++ b/src/pages/DashboardProjectsEditor.tsx
@@ -2808,6 +2808,7 @@ const DashboardProjectsEditor = () => {
                                                               type="button"
                                                               tone="destructive"
                                                               size="icon"
+                                                              aria-label="Remover link de download"
                                                               onClick={() => {
                                                                 setFormState((prev) => {
                                                                   const next = [
@@ -2829,7 +2830,7 @@ const DashboardProjectsEditor = () => {
                                                                 });
                                                               }}
                                                             >
-                                                              <Trash2 className="h-4 w-4" />
+                                                              <Trash2 className="h-4 w-4" aria-hidden="true" />
                                                             </DashboardActionButton>
                                                           </div>
                                                         </div>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only `DashboardActionButton`s and `aria-hidden="true"` to their inner SVGs.
🎯 Why: Icon-only buttons lacked accessible names, making them difficult for screen reader users to understand their function.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Improves WCAG compliance by ensuring all interactive elements have accessible names (in Portuguese to match the UI language) and hiding redundant SVGs from screen readers.

---
*PR created automatically by Jules for task [11658035727188436460](https://jules.google.com/task/11658035727188436460) started by @Gavuriiru*