### PR TITLE
🔒 Sentinel: [HIGH] Fix Host Header Injection in PWA bootstrap policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,7 @@
 **Vulnerability:** Raw HTML strings were assigned to `innerHTML` sinks without sanitization within `src/lexical-playground/nodes/ImageNode.tsx` and `src/lexical-playground/hooks/useReport.ts`.
 **Learning:** Even within an encapsulated rich-text editor setup or helper hooks, directly passing HTML strings to `innerHTML` exposes an XSS risk if those strings can be populated with user content.
 **Prevention:** Always sanitize strings with `DOMPurify.sanitize` (using strict profiles like `{ USE_PROFILES: { html: true } }` where appropriate) before rendering them via `innerHTML` or `dangerouslySetInnerHTML`.
+## 2024-05-18 - Host Header Injection Prevention
+**Vulnerability:** The application was manually parsing the `x-forwarded-host` header to resolve the request hostname in `server/lib/pwa-bootstrap-policy.js` (`resolveBootstrapPwaRequestHostname`).
+**Learning:** This manual parsing bypassed Express's built-in `trust proxy` configuration, potentially allowing attackers to spoof the host header (Host Header Injection) even if the server was not properly configured to trust the upstream proxy.
+**Prevention:** Rely on framework-level hostname resolution (e.g., Express's `req.hostname`) which respects `trust proxy` settings by default. This ensures the application only trusts forwarded headers when explicitly configured to do so at the infrastructure level.

--- a/server/lib/pwa-bootstrap-policy.js
+++ b/server/lib/pwa-bootstrap-policy.js
@@ -19,15 +19,15 @@ export const isLoopbackHostname = (value) => {
 };
 
 export const resolveBootstrapPwaRequestHostname = (req) => {
+  // Rely securely on Express's req.hostname which respects the 'trust proxy' configuration
+  // instead of manually parsing the user-controlled 'x-forwarded-host' header.
+  // This mitigates potential Host Header Injection vulnerabilities.
   const requestHostname = normalizeHostname(req?.hostname);
   if (requestHostname) {
     return requestHostname;
   }
 
-  const rawForwardedHost = String(req?.headers?.["x-forwarded-host"] || "")
-    .split(",")[0]
-    .trim();
-  const rawHost = rawForwardedHost || String(req?.headers?.host || "").trim();
+  const rawHost = String(req?.headers?.host || "").trim();
   if (!rawHost) {
     return "";
   }


### PR DESCRIPTION
Removed manual parsing of the `x-forwarded-host` header in `server/lib/pwa-bootstrap-policy.js` to rely on Express's `req.hostname` property, securely mitigating Host Header Injection risks by honoring the framework's `trust proxy` configuration.

---
*PR created automatically by Jules for task [16082805339384758349](https://jules.google.com/task/16082805339384758349) started by @Gavuriiru*