### PR TITLE
🎨 Palette: Add ARIA labels to social link remove buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2026-05-16 - Added ARIA labels to DashboardSettingsSocialLinksTab Trash Buttons
+**Learning:** Found more icon-only action buttons (e.g. `Trash2`) in `DashboardSettingsSocialLinksTab.tsx` missing `aria-label`s. This reinforces the pattern that icon-only `DashboardActionButton`s in the dashboard configuration forms frequently lack accessibility labels.
+**Action:** Always verify icon-only buttons have descriptive `aria-label`s and add `aria-hidden="true"` to the nested icons to prevent redundant screen reader announcements.

--- a/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Plus, Save, Trash2 } from "lucide-react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Save, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -134,11 +134,12 @@ export const DashboardSettingsSocialLinksTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveSvgCardMobileRemoveButtonClass}
+                        aria-label={`Remover rede ${link.label || index + 1}`}
                         onClick={() =>
                           setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
@@ -146,9 +147,10 @@ export const DashboardSettingsSocialLinksTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
+                    aria-label={`Remover rede ${link.label || index + 1}`}
                     onClick={() => setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))}
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to the "Remove" icon-only buttons in the Dashboard Settings Social Links Tab, and applied `aria-hidden="true"` to their internal `Trash2` Lucide icons.
🎯 **Why:** To provide proper context for assistive technologies (like screen readers) when users encounter these icon-only buttons, preventing redundant icon announcements.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Users with screen readers will now hear a descriptive label (e.g., "Remover rede Twitter") instead of generic or no feedback when focusing on the delete buttons for social links.

---
*PR created automatically by Jules for task [12214768879291293009](https://jules.google.com/task/12214768879291293009) started by @Gavuriiru*