### PR TITLE
🎨 Palette: Add ARIA labels to icon-only DashboardActionButtons in settings

### DIFF
--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -92,6 +92,7 @@ export const DashboardSettingsTeamTab = () => {
                 <DashboardActionButton
                   type="button"
                   size="icon"
+                  aria-label="Remover cargo da equipe"
                   className={responsiveCompactRowDeleteButtonClass}
                   onClick={() =>
                     setSettings((prev) => ({
@@ -100,7 +101,7 @@ export const DashboardSettingsTeamTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}

--- a/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
-import { Card, CardContent } from "@/components/ui/card";
-import { TabsContent } from "@/components/ui/tabs";
 import { Download, Plus, Save, Trash2 } from "lucide-react";
 import type { UIEvent } from "react";
 import { useState } from "react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Card, CardContent } from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -181,6 +181,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução de tag: ${tag}`}
                             onClick={() =>
                               setTagTranslations((prev) => {
                                 const next = { ...prev };
@@ -189,7 +190,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -317,6 +318,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução de gênero: ${genre}`}
                             onClick={() =>
                               setGenreTranslations((prev) => {
                                 const next = { ...prev };
@@ -325,7 +327,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -448,6 +450,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução de cargo: ${role}`}
                             onClick={() =>
                               setStaffRoleTranslations((prev) => {
                                 const next = { ...prev };
@@ -456,7 +459,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to multiple icon-only `DashboardActionButton`s in the Dashboard Settings layout, and `aria-hidden="true"` to their nested `Trash2` icons.
🎯 Why: These buttons (often used for deleting rows in complex form arrays) lacked accessible names, making them unreadable by screen readers.
📸 Before/After: N/A (non-visual change)
♿ Accessibility: Improves screen reader support by correctly labeling icon-only buttons in Portuguese ("Remover cargo da equipe", "Remover tradução de tag", etc.) and preventing redundant icon announcements.

---
*PR created automatically by Jules for task [18304567777668125956](https://jules.google.com/task/18304567777668125956) started by @Gavuriiru*