### PR TITLE
🎨 Palette: Adicionar aria-labels a botões de ação de postagem

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+
+## 2024-05-19 - Added ARIA labels and aria-hidden to Icon-only Buttons
+**Learning:** Icon-only action buttons (e.g. `DashboardActionButton` wrapping `lucide-react` icons) are frequently missing `aria-label` attributes and the icons themselves lack `aria-hidden="true"`, causing poor screen reader experience (announcing "button" without context, and potentially reading out the SVG). Additionally, when using Radix UI's `asChild` on these wrappers, the `aria-label` correctly propagates down to the underlying element (like `<Link>`).
+**Action:** Always add descriptive `aria-label`s in Portuguese to icon-only buttons, and explicitly add `aria-hidden="true"` to nested `lucide-react` icons. Check for `asChild` usage to ensure labels are placed correctly on the wrapper.

--- a/src/pages/DashboardPosts.tsx
+++ b/src/pages/DashboardPosts.tsx
@@ -1,6 +1,26 @@
+import {
+  CalendarDays,
+  Copy,
+  Eye,
+  List as ListIcon,
+  MessageSquare,
+  Plus,
+  RotateCcw,
+  Trash2,
+  UserRound,
+} from "lucide-react";
+import {
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Link, Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
-import ProjectEmbedCard from "@/components/ProjectEmbedCard";
-import UploadPicture from "@/components/UploadPicture";
 import DashboardActionButton, {
   default as Button,
 } from "@/components/dashboard/DashboardActionButton";
@@ -36,6 +56,8 @@ import {
 import LazyImageLibraryDialog from "@/components/lazy/LazyImageLibraryDialog";
 import type { LexicalEditorHandle } from "@/components/lexical/LexicalEditor";
 import LexicalEditorSurface from "@/components/lexical/LexicalEditorSurface";
+import ProjectEmbedCard from "@/components/ProjectEmbedCard";
+import UploadPicture from "@/components/UploadPicture";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import AsyncState from "@/components/ui/async-state";
 import { Badge } from "@/components/ui/badge";
@@ -97,28 +119,6 @@ import { getImageFileNameFromUrl, resolvePostCoverPreview } from "@/lib/post-cov
 import { buildTranslationMap, sortByTranslatedLabel, translateTag } from "@/lib/project-taxonomy";
 import { normalizeUploadVariantUrlKey, type UploadMediaVariantsMap } from "@/lib/upload-variants";
 import type { ContentVersion, EditorialCalendarItem } from "@/types/editorial";
-import {
-  CalendarDays,
-  Copy,
-  Eye,
-  List as ListIcon,
-  MessageSquare,
-  Plus,
-  RotateCcw,
-  Trash2,
-  UserRound,
-} from "lucide-react";
-import {
-  type CSSProperties,
-  type KeyboardEvent as ReactKeyboardEvent,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { Link, Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 const POST_EDITOR_TOOLBAR_STICKY_OFFSET_PX = 5;
 
@@ -2616,34 +2616,40 @@ const DashboardPosts = () => {
                                 <DashboardActionButton
                                   size="icon-sm"
                                   title="Visualizar"
+                                  aria-label="Visualizar postagem"
                                   onClick={(event) => event.stopPropagation()}
                                   asChild
                                 >
                                   <Link to={`/postagem/${post.slug}`}>
-                                    <Eye className="h-3.5 w-3.5" />
+                                    <Eye aria-hidden="true" className="h-3.5 w-3.5" />
                                   </Link>
                                 </DashboardActionButton>
                                 <DashboardActionButton
                                   size="icon-sm"
                                   title="Copiar link"
+                                  aria-label="Copiar link da postagem"
                                   onClick={(event) => {
                                     event.stopPropagation();
                                     handleCopyLink(post.slug);
                                   }}
                                 >
-                                  <Copy className="h-3.5 w-3.5" />
+                                  <Copy aria-hidden="true" className="h-3.5 w-3.5" />
                                 </DashboardActionButton>
                                 {canManagePosts ? (
                                   <DashboardActionButton
                                     tone="destructive"
                                     size="icon-sm"
                                     title="Excluir"
+                                    aria-label="Excluir postagem"
                                     onClick={(event) => {
                                       event.stopPropagation();
                                       handleDeletePost(post);
                                     }}
                                   >
-                                    <Trash2 className="h-3.5 w-3.5 text-destructive" />
+                                    <Trash2
+                                      aria-hidden="true"
+                                      className="h-3.5 w-3.5 text-destructive"
+                                    />
                                   </DashboardActionButton>
                                 ) : null}
                               </div>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label`s to the icon-only buttons ("Visualizar", "Copiar link", "Excluir") on the Dashboard Posts page, and applied `aria-hidden="true"` to their inner `lucide-react` icons. 
🎯 **Why:** Icon-only buttons without `aria-label` are announced simply as "button" by screen readers, offering no context to visually impaired users. Furthermore, raw SVG icons can sometimes be redundantly announced if not explicitly hidden.
📸 **Before/After:** Not a visual change. 
♿ **Accessibility:** This ensures screen readers correctly announce the actions (e.g. "Visualizar postagem") while ignoring the visual icon, dramatically improving keyboard navigation and AT experience. Also recorded these learnings in the UX journal.

---
*PR created automatically by Jules for task [14759234508329645814](https://jules.google.com/task/14759234508329645814) started by @Gavuriiru*