### PR TITLE
⚡ Bolt: Replace O(N log N) localeCompare calls with Intl.Collator in Dashboard

### DIFF
--- a/src/pages/DashboardPosts.tsx
+++ b/src/pages/DashboardPosts.tsx
@@ -1,6 +1,26 @@
+import {
+  CalendarDays,
+  Copy,
+  Eye,
+  List as ListIcon,
+  MessageSquare,
+  Plus,
+  RotateCcw,
+  Trash2,
+  UserRound,
+} from "lucide-react";
+import {
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Link, Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
-import ProjectEmbedCard from "@/components/ProjectEmbedCard";
-import UploadPicture from "@/components/UploadPicture";
 import DashboardActionButton, {
   default as Button,
 } from "@/components/dashboard/DashboardActionButton";
@@ -36,6 +56,8 @@ import {
 import LazyImageLibraryDialog from "@/components/lazy/LazyImageLibraryDialog";
 import type { LexicalEditorHandle } from "@/components/lexical/LexicalEditor";
 import LexicalEditorSurface from "@/components/lexical/LexicalEditorSurface";
+import ProjectEmbedCard from "@/components/ProjectEmbedCard";
+import UploadPicture from "@/components/UploadPicture";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import AsyncState from "@/components/ui/async-state";
 import { Badge } from "@/components/ui/badge";
@@ -95,30 +117,9 @@ import { filterImageLibraryFoldersByAccess } from "@/lib/image-library-scope";
 import { createSlug, getLexicalText } from "@/lib/post-content";
 import { getImageFileNameFromUrl, resolvePostCoverPreview } from "@/lib/post-cover";
 import { buildTranslationMap, sortByTranslatedLabel, translateTag } from "@/lib/project-taxonomy";
+import { comparePtBr } from "@/lib/search-ranking";
 import { normalizeUploadVariantUrlKey, type UploadMediaVariantsMap } from "@/lib/upload-variants";
 import type { ContentVersion, EditorialCalendarItem } from "@/types/editorial";
-import {
-  CalendarDays,
-  Copy,
-  Eye,
-  List as ListIcon,
-  MessageSquare,
-  Plus,
-  RotateCcw,
-  Trash2,
-  UserRound,
-} from "lucide-react";
-import {
-  type CSSProperties,
-  type KeyboardEvent as ReactKeyboardEvent,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { Link, Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 const POST_EDITOR_TOOLBAR_STICKY_OFFSET_PX = 5;
 
@@ -1008,7 +1009,7 @@ const DashboardPosts = () => {
     const next = [...filteredPosts];
     next.sort((a, b) => {
       if (sortMode === "alpha") {
-        return a.title.localeCompare(b.title, "pt-BR");
+        return comparePtBr(a.title, b.title);
       }
       if (sortMode === "tags") {
         const tagsA = [
@@ -1019,10 +1020,10 @@ const DashboardPosts = () => {
           ...(b.projectId ? projectMap.get(b.projectId)?.tags || [] : []),
           ...(Array.isArray(b.tags) ? b.tags : []),
         ];
-        return tagsA.join(",").localeCompare(tagsB.join(","), "pt-BR");
+        return comparePtBr(tagsA.join(","), tagsB.join(","));
       }
       if (sortMode === "status") {
-        return a.status.localeCompare(b.status, "pt-BR");
+        return comparePtBr(a.status, b.status);
       }
       if (sortMode === "views") {
         return (b.views || 0) - (a.views || 0);

--- a/src/pages/DashboardProjectsEditor.tsx
+++ b/src/pages/DashboardProjectsEditor.tsx
@@ -1,3 +1,16 @@
+import {
+  Clapperboard,
+  Copy,
+  Eye,
+  FileImage,
+  FileText,
+  type LucideIcon,
+  PencilLine,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton, {
   default as Button,
@@ -16,6 +29,11 @@ import {
   dashboardStrongSurfaceHoverClassName,
   dashboardSubtleSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
+import type {
+  EditorProjectEpisode,
+  ProjectForm,
+  ProjectRecord,
+} from "@/components/dashboard/project-editor/dashboard-projects-editor-types";
 import ProjectEditorDialogShell from "@/components/dashboard/project-editor/ProjectEditorDialogShell";
 import ProjectEditorImageLibraryDialog from "@/components/dashboard/project-editor/ProjectEditorImageLibraryDialog";
 import ProjectEditorImportSection from "@/components/dashboard/project-editor/ProjectEditorImportSection";
@@ -28,11 +46,6 @@ import {
   ProjectEditorConfirmDialog,
   ProjectEditorDeleteDialog,
 } from "@/components/dashboard/project-editor/ProjectEditorSupportDialogs";
-import type {
-  EditorProjectEpisode,
-  ProjectForm,
-  ProjectRecord,
-} from "@/components/dashboard/project-editor/dashboard-projects-editor-types";
 import { DEFAULT_PROJECT_FORMAT_OPTIONS } from "@/components/dashboard/project-editor/project-editor-constants";
 import {
   buildEmptyProjectForm,
@@ -84,19 +97,7 @@ import { resolveEpisodeLookup } from "@/lib/project-episode-key";
 import { isChapterBasedType, isLightNovelType, isMangaType } from "@/lib/project-utils";
 import { buildVolumeCoverKey } from "@/lib/project-volume-cover-key";
 import { reorderItems } from "@/lib/reorder-items";
-import {
-  Clapperboard,
-  Copy,
-  Eye,
-  FileImage,
-  FileText,
-  type LucideIcon,
-  PencilLine,
-  Plus,
-  Trash2,
-} from "lucide-react";
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { comparePtBr } from "@/lib/search-ranking";
 
 const getDedicatedEditorCtaIcon = (projectType?: string | null): LucideIcon => {
   const normalizedType = String(projectType || "").trim();
@@ -435,7 +436,7 @@ const DashboardProjectsEditor = () => {
       .map((project) => String(project.type || "").trim())
       .filter(Boolean);
     const unique = Array.from(new Set(types));
-    const sorted = unique.sort((a, b) => a.localeCompare(b, "pt-BR"));
+    const sorted = unique.sort(comparePtBr);
     return ["Todos", ...sorted];
   }, [activeProjects]);
   const formatSelectOptions = useMemo(() => {
@@ -444,7 +445,7 @@ const DashboardProjectsEditor = () => {
     const merged = Array.from(
       new Set([...fromApi, ...defaultFormatOptions, currentType].filter(Boolean)),
     );
-    return merged.sort((a, b) => a.localeCompare(b, "pt-BR"));
+    return merged.sort(comparePtBr);
   }, [formState.type, projectTypeOptions]);
 
   useEffect(() => {
@@ -488,11 +489,11 @@ const DashboardProjectsEditor = () => {
     }
     const next = [...filteredProjects];
     if (sortMode === "alpha") {
-      next.sort((a, b) => a.title.localeCompare(b.title, "pt-BR"));
+      next.sort((a, b) => comparePtBr(a.title, b.title));
       return next;
     }
     if (sortMode === "status") {
-      next.sort((a, b) => a.status.localeCompare(b.status, "pt-BR"));
+      next.sort((a, b) => comparePtBr(a.status, b.status));
       return next;
     }
     if (sortMode === "views") {
@@ -503,7 +504,7 @@ const DashboardProjectsEditor = () => {
       next.sort((a, b) => (b.commentsCount || 0) - (a.commentsCount || 0));
       return next;
     }
-    next.sort((a, b) => a.title.localeCompare(b.title, "pt-BR"));
+    next.sort((a, b) => comparePtBr(a.title, b.title));
     return next;
   }, [filteredProjects, sortMode]);
   const projectsPerPage = 10;


### PR DESCRIPTION
💡 **What**:
Replaced inline `String.prototype.localeCompare` calls inside `Array.prototype.sort()` comparators with the pre-instantiated `comparePtBr` utility (which wraps a single `Intl.Collator`) in the Dashboard Posts and Projects views.

🎯 **Why**:
Using `localeCompare` directly inside a sort comparator is a well-known performance bottleneck in JavaScript because it instantiates a new `Intl.Collator` object for every comparison (which happens O(N log N) times during a sort). For large lists of posts or projects, this causes unnecessary garbage collection and main thread blocking.

📊 **Impact**:
Eliminates O(N log N) `Intl.Collator` instantiations during alphabetical sorting operations on the dashboard, significantly speeding up the sort time and reducing main thread UI blocking when interacting with the grid view.

🔬 **Measurement**:
The impact can be verified by running a performance profile in the browser's DevTools. Before the change, clicking the "A-Z" sort header on a large list of projects/posts would show a heavy self-time on `localeCompare`. After this change, the collator comparison is near-instant as it reuses a single reference.

---
*PR created automatically by Jules for task [356666622260832414](https://jules.google.com/task/356666622260832414) started by @Gavuriiru*