### PR TITLE
🎨 Palette: add specific ARIA labels to dashboard widget reorder buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+
+## 2024-05-18 - [Descriptive ARIA Labels in Dynamic Lists]
+**Learning:** Found that generic or missing ARIA labels on icon-only buttons (like ArrowUp/ArrowDown) used inside dynamic, mapped lists (e.g., reordering dashboard widgets) make it impossible for screen reader users to know *which* item they are interacting with.
+**Action:** Always ensure ARIA labels in mapped loops use specific dynamic content (e.g., \`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima\`) rather than static text, and ensure the nested SVG icons include `aria-hidden="true"`.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,6 @@
+import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardPageBadge from "@/components/dashboard/DashboardPageBadge";
@@ -26,14 +29,11 @@ import { toast } from "@/components/ui/use-toast";
 import { useDashboardCurrentUser } from "@/hooks/use-dashboard-current-user";
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences";
 import { usePageMeta } from "@/hooks/use-page-meta";
+import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
-import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { formatDateTime } from "@/lib/date";
 import type { OperationalAlertsResponse } from "@/types/operational-alerts";
-import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 type DashboardPost = {
   id: string;
@@ -1409,16 +1409,18 @@ const Dashboard = () => {
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para baixo`}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"


### PR DESCRIPTION
💡 **What:** Added descriptive, dynamic `aria-label` attributes to the "ArrowUp" and "ArrowDown" icon-only buttons used for reordering widgets in the dashboard settings, and applied `aria-hidden="true"` to their inner SVG elements.

🎯 **Why:** Previously, these buttons had no text alternative, leaving screen reader users without context about their purpose or *which* widget they would affect. Adding specific dynamic text ensures accessibility and independence.

📸 **Before/After:** No visual changes.

♿ **Accessibility:** Screen readers will now announce "Mover widget [Widget Name] para cima/baixo" instead of just identifying a blank button, significantly improving context and ease of navigation for keyboard and screen reader users.

---
*PR created automatically by Jules for task [8427414431492299888](https://jules.google.com/task/8427414431492299888) started by @Gavuriiru*