### PR TITLE
🎨 Palette: Add ARIA labels to Dashboard Widget Ordering Buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## $(date +%Y-%m-%d) - Dashboard Action Buttons missing aria-label
+**Learning:** Icon-only buttons mapping across lists or collections in the dashboard layout frequently lack \`aria-label\` attributes.
+**Action:** Always ensure \`DashboardActionButton\`s mapping over data lists have descriptive \`aria-label\`s with specific dynamic context (e.g., using item labels or IDs like \`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima\`) rather than generic text. Also use \`aria-hidden="true"\` to prevent redundant screen reader announcements on the embedded Lucide icons. Ensure all tags continue to be written in Portuguese to maintain consistency.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,6 @@
+import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardPageBadge from "@/components/dashboard/DashboardPageBadge";
@@ -26,14 +29,11 @@ import { toast } from "@/components/ui/use-toast";
 import { useDashboardCurrentUser } from "@/hooks/use-dashboard-current-user";
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences";
 import { usePageMeta } from "@/hooks/use-page-meta";
+import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
-import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { formatDateTime } from "@/lib/date";
 import type { OperationalAlertsResponse } from "@/types/operational-alerts";
-import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 type DashboardPost = {
   id: string;
@@ -1409,16 +1409,18 @@ const Dashboard = () => {
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para baixo`}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"


### PR DESCRIPTION
💡 **What:** Adicionado atributos `aria-label` dinâmicos aos botões de ordenação (setas para cima e para baixo) no modal de "Custom Draft Widgets" e adicionado `aria-hidden="true"` aos ícones Lucide internos.
🎯 **Why:** Os botões consistiam apenas de ícones (`ArrowUp` e `ArrowDown`), tornando-os inacessíveis para leitores de tela e dificultando o entendimento da função para pessoas com deficiência visual.
📸 **Before/After:** Mudança estrutural em HTML; não afeta o design visual.
♿ **Accessibility:** Leitores de tela agora anunciarão corretamente ações específicas, ex: "Mover widget Atividade Recente para cima", melhorando significativamente a navegação por teclado e acessibilidade sem afetar a estrutura visual.

---
*PR created automatically by Jules for task [11368156139037111104](https://jules.google.com/task/11368156139037111104) started by @Gavuriiru*