### PR TITLE
🛡️ Sentinel: [HIGH] Fix Host Header Injection in PWA Bootstrap Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,7 @@
 **Vulnerability:** Raw HTML strings were assigned to `innerHTML` sinks without sanitization within `src/lexical-playground/nodes/ImageNode.tsx` and `src/lexical-playground/hooks/useReport.ts`.
 **Learning:** Even within an encapsulated rich-text editor setup or helper hooks, directly passing HTML strings to `innerHTML` exposes an XSS risk if those strings can be populated with user content.
 **Prevention:** Always sanitize strings with `DOMPurify.sanitize` (using strict profiles like `{ USE_PROFILES: { html: true } }` where appropriate) before rendering them via `innerHTML` or `dangerouslySetInnerHTML`.
+## 2026-04-20 - [Host Header Injection] Bypassing Express trust proxy
+**Vulnerability:** The application manually parsed `x-forwarded-host` headers to determine the request hostname. This bypasses Express's built-in `trust proxy` mechanism and allows attackers to spoof the host header.
+**Learning:** When an application is behind a reverse proxy and configured with `app.set("trust proxy", 1)`, Express securely resolves the correct client IP and hostname. Manually reading `req.headers["x-forwarded-host"]` ignores this security and trusts potentially malicious input.
+**Prevention:** Rely entirely on framework-level properties like `req.hostname` to resolve hostnames, which securely factors in proxy configuration, rather than reading raw forwarded headers.

--- a/server/lib/pwa-bootstrap-policy.js
+++ b/server/lib/pwa-bootstrap-policy.js
@@ -24,10 +24,7 @@ export const resolveBootstrapPwaRequestHostname = (req) => {
     return requestHostname;
   }
 
-  const rawForwardedHost = String(req?.headers?.["x-forwarded-host"] || "")
-    .split(",")[0]
-    .trim();
-  const rawHost = rawForwardedHost || String(req?.headers?.host || "").trim();
+  const rawHost = String(req?.headers?.host || "").trim();
   if (!rawHost) {
     return "";
   }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Host Header Injection. The `resolveBootstrapPwaRequestHostname` function manually parsed the `x-forwarded-host` header instead of relying on Express's secure `req.hostname` resolution. This ignores the `trust proxy` configuration and trusts potentially malicious input.
🎯 **Impact**: Attackers could spoof the host header to perform Host Header Injection, potentially leading to cache poisoning, password reset poisoning, or bypassing security checks relying on hostname validation.
🔧 **Fix**: Modified `server/lib/pwa-bootstrap-policy.js` to rely exclusively on `req.hostname` (which respects proxy settings securely) and falling back directly to `req.headers.host` if missing, completely bypassing manual resolution of forwarded headers.
✅ **Verification**: Run `npx vitest run src/server/pwa-bootstrap-policy.test.ts` to confirm no regressions occur in resolving loopback hostnames for PWA bootstrap configuration.

---
*PR created automatically by Jules for task [10122776570364203918](https://jules.google.com/task/10122776570364203918) started by @Gavuriiru*