### PR TITLE
🎨 Palette: Add ARIA labels and aria-hidden to icon-only buttons

### DIFF
--- a/src/components/ReorderControls.tsx
+++ b/src/components/ReorderControls.tsx
@@ -1,8 +1,8 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+import type { KeyboardEvent } from "react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import { useAccessibilityAnnouncer } from "@/hooks/accessibility-announcer";
 import { cn } from "@/lib/utils";
-import { ChevronDown, ChevronUp } from "lucide-react";
-import type { KeyboardEvent } from "react";
 
 type ReorderControlsProps = {
   label: string;

--- a/src/components/dashboard/chapter-editor/ChapterEditorStructureSection.tsx
+++ b/src/components/dashboard/chapter-editor/ChapterEditorStructureSection.tsx
@@ -1,3 +1,14 @@
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronRight,
+  ExternalLink,
+  FileArchive,
+  Loader2,
+  Plus,
+  Search,
+} from "lucide-react";
+import { memo, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import { Combobox, Input } from "@/components/dashboard/dashboard-form-controls";
 import {
@@ -15,27 +26,16 @@ import {
 import { Badge } from "@/components/ui/badge";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import {
-  chapterHasContent,
-  chapterStatusLabel,
   type ChapterFilterMode,
   type ChapterStructureGroup,
+  chapterHasContent,
+  chapterStatusLabel,
 } from "@/lib/dashboard-project-chapter";
 import {
   buildDashboardProjectChapterEditorHref,
   buildProjectPublicReadingHref,
 } from "@/lib/project-editor-routes";
 import { buildEpisodeKey } from "@/lib/project-episode-key";
-import {
-  ArrowDown,
-  ArrowUp,
-  ChevronRight,
-  ExternalLink,
-  FileArchive,
-  Loader2,
-  Plus,
-  Search,
-} from "lucide-react";
-import { memo, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import {
   normalizeProjectEpisodeContentFormat,
   normalizeProjectEpisodePages,
@@ -282,6 +282,7 @@ export const ChapterEditorStructureSection = memo(
                         >
                           <ChevronRight
                             className={`h-4 w-4 transition-transform ${isOpen ? "rotate-90" : ""}`}
+                            aria-hidden="true"
                           />
                         </DashboardActionButton>
                       </div>
@@ -518,7 +519,7 @@ export const ChapterEditorStructureSection = memo(
                                                 size="icon"
                                                 tone="neutral"
                                                 data-testid={`chapter-structure-episode-move-up-${episodeKey}`}
-                                                aria-label="Mover item para cima"
+                                                aria-label={`Mover capítulo ${episode.number} para cima`}
                                                 className="h-9 w-9 rounded-xl bg-background/92"
                                                 onClick={(event) => {
                                                   event.stopPropagation();
@@ -530,9 +531,15 @@ export const ChapterEditorStructureSection = memo(
                                                 }
                                               >
                                                 {isReorderingEpisodeUp ? (
-                                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                                  <Loader2
+                                                    className="h-4 w-4 animate-spin"
+                                                    aria-hidden="true"
+                                                  />
                                                 ) : (
-                                                  <ArrowUp className="h-4 w-4" />
+                                                  <ChevronUp
+                                                    className="h-4 w-4"
+                                                    aria-hidden="true"
+                                                  />
                                                 )}
                                               </DashboardActionButton>
                                               <DashboardActionButton
@@ -540,7 +547,7 @@ export const ChapterEditorStructureSection = memo(
                                                 size="icon"
                                                 tone="neutral"
                                                 data-testid={`chapter-structure-episode-move-down-${episodeKey}`}
-                                                aria-label="Mover item para baixo"
+                                                aria-label={`Mover capítulo ${episode.number} para baixo`}
                                                 className="h-9 w-9 rounded-xl bg-background/92"
                                                 onClick={(event) => {
                                                   event.stopPropagation();
@@ -555,9 +562,15 @@ export const ChapterEditorStructureSection = memo(
                                                 }
                                               >
                                                 {isReorderingEpisodeDown ? (
-                                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                                  <Loader2
+                                                    className="h-4 w-4 animate-spin"
+                                                    aria-hidden="true"
+                                                  />
                                                 ) : (
-                                                  <ArrowDown className="h-4 w-4" />
+                                                  <ChevronDown
+                                                    className="h-4 w-4"
+                                                    aria-hidden="true"
+                                                  />
                                                 )}
                                               </DashboardActionButton>
                                             </>
@@ -575,7 +588,10 @@ export const ChapterEditorStructureSection = memo(
                                                 handleOpenReadingPage();
                                               }}
                                             >
-                                              <ExternalLink className="h-4 w-4" />
+                                              <ExternalLink
+                                                className="h-4 w-4"
+                                                aria-hidden="true"
+                                              />
                                             </DashboardActionButton>
                                           ) : null}
                                         </div>

--- a/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
@@ -1,3 +1,5 @@
+import { Plus, Trash2 } from "lucide-react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import { Input } from "@/components/dashboard/dashboard-form-controls";
 import {
   dashboardStrongFocusFieldClassName,
@@ -5,14 +7,12 @@ import {
   dashboardStrongFocusTriggerClassName,
   dashboardStrongSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -184,6 +184,7 @@ export const DashboardSettingsDownloadsTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveSvgCardMobileRemoveButtonClass}
+                        aria-label={`Remover fonte ${source.label || index + 1}`}
                         onClick={() =>
                           setSettings((prev) => ({
                             ...prev,
@@ -194,7 +195,7 @@ export const DashboardSettingsDownloadsTab = () => {
                           }))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
@@ -202,6 +203,7 @@ export const DashboardSettingsDownloadsTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
+                    aria-label={`Remover fonte ${source.label || index + 1}`}
                     onClick={() =>
                       setSettings((prev) => ({
                         ...prev,
@@ -212,7 +214,7 @@ export const DashboardSettingsDownloadsTab = () => {
                       }))
                     }
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsLayoutTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsLayoutTab.tsx
@@ -1,14 +1,14 @@
-import { Combobox, Input, Textarea } from "@/components/dashboard/dashboard-form-controls";
+import { GripVertical, Link2, Plus, Trash2 } from "lucide-react";
+import { useMemo } from "react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardFieldStack from "@/components/dashboard/DashboardFieldStack";
+import { Combobox, Input, Textarea } from "@/components/dashboard/dashboard-form-controls";
 import ReorderControls from "@/components/ReorderControls";
 import { Card, CardContent } from "@/components/ui/card";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
 import { navbarIconOptions } from "@/lib/navbar-icons";
-import { GripVertical, Link2, Plus, Trash2 } from "lucide-react";
-import { useMemo } from "react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -152,7 +152,7 @@ export const DashboardSettingsLayoutTab = () => {
                   type="button"
                   size="icon"
                   className={responsiveCompactRowDeleteButtonClass}
-                  aria-label="Remover link da navbar"
+                  aria-label={`Remover link da navbar ${link.label || index + 1}`}
                   onClick={() =>
                     setSettings((prev) => ({
                       ...prev,
@@ -163,7 +163,7 @@ export const DashboardSettingsLayoutTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}
@@ -252,7 +252,7 @@ export const DashboardSettingsLayoutTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveCompactSelfEndDeleteButtonClass}
-                    aria-label="Remover coluna do footer"
+                    aria-label={`Remover coluna ${column.title || columnIndex + 1} do footer`}
                     onClick={() =>
                       setSettings((prev) => ({
                         ...prev,
@@ -263,7 +263,7 @@ export const DashboardSettingsLayoutTab = () => {
                       }))
                     }
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
                 <div className="grid gap-3">
@@ -320,7 +320,7 @@ export const DashboardSettingsLayoutTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveCompactRowDeleteButtonClass}
-                        aria-label="Remover link da coluna do footer"
+                        aria-label={`Remover link ${link.label || linkIndex + 1} da coluna do footer`}
                         onClick={() =>
                           setSettings((prev) => {
                             const nextColumns = [...prev.footer.columns];
@@ -338,7 +338,7 @@ export const DashboardSettingsLayoutTab = () => {
                           })
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   ))}
@@ -449,7 +449,7 @@ export const DashboardSettingsLayoutTab = () => {
                         }))
                       }
                     >
-                      <Trash2 className="h-4 w-4" />
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                   </div>
                   <Combobox
@@ -511,7 +511,7 @@ export const DashboardSettingsLayoutTab = () => {
                       }))
                     }
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               </div>
@@ -550,7 +550,7 @@ export const DashboardSettingsLayoutTab = () => {
                       type="button"
                       size="icon"
                       className={responsiveCompactRowDeleteButtonClass}
-                      aria-label="Remover parágrafo do aviso legal"
+                      aria-label={`Remover parágrafo ${index + 1} do aviso legal`}
                       onClick={() =>
                         setSettings((prev) => ({
                           ...prev,
@@ -561,7 +561,7 @@ export const DashboardSettingsLayoutTab = () => {
                         }))
                       }
                     >
-                      <Trash2 className="h-4 w-4" />
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                   </div>
                 ))}

--- a/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Plus, Save, Trash2 } from "lucide-react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Save, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -134,11 +134,12 @@ export const DashboardSettingsSocialLinksTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveSvgCardMobileRemoveButtonClass}
+                        aria-label={`Remover rede ${link.label || index + 1}`}
                         onClick={() =>
                           setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
@@ -146,9 +147,10 @@ export const DashboardSettingsSocialLinksTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
+                    aria-label={`Remover rede ${link.label || index + 1}`}
                     onClick={() => setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))}
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -93,6 +93,7 @@ export const DashboardSettingsTeamTab = () => {
                   type="button"
                   size="icon"
                   className={responsiveCompactRowDeleteButtonClass}
+                  aria-label={`Remover cargo ${role.label || index + 1}`}
                   onClick={() =>
                     setSettings((prev) => ({
                       ...prev,
@@ -100,7 +101,7 @@ export const DashboardSettingsTeamTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}

--- a/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
-import { Card, CardContent } from "@/components/ui/card";
-import { TabsContent } from "@/components/ui/tabs";
 import { Download, Plus, Save, Trash2 } from "lucide-react";
 import type { UIEvent } from "react";
 import { useState } from "react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Card, CardContent } from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -181,6 +181,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução de ${tag}`}
                             onClick={() =>
                               setTagTranslations((prev) => {
                                 const next = { ...prev };
@@ -189,7 +190,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -317,6 +318,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução de ${genre}`}
                             onClick={() =>
                               setGenreTranslations((prev) => {
                                 const next = { ...prev };
@@ -325,7 +327,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -448,6 +450,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução de ${role}`}
                             onClick={() =>
                               setStaffRoleTranslations((prev) => {
                                 const next = { ...prev };
@@ -456,7 +459,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to various icon-only buttons (like delete, move up/down, open) and `aria-hidden="true"` to their internal SVG icons.
🎯 **Why:** To improve accessibility for screen reader users by providing descriptive context for these actions and preventing redundant announcements of generic icons.
📸 **Before/After:** Not applicable (non-visual change, strictly a11y HTML attributes).
♿ **Accessibility:** Solves missing label errors for interactive `<button>` elements, ensuring they are properly announced and understood via assistive technology.

---
*PR created automatically by Jules for task [15274948452226435245](https://jules.google.com/task/15274948452226435245) started by @Gavuriiru*