### PR TITLE
🎨 Palette: Add ARIA labels to dashboard widget reordering buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## $(date +%Y-%m-%d) - Added ARIA labels to Dashboard Widget Reordering Buttons
+**Learning:** Icon-only buttons used for reordering elements (like `ArrowUp` and `ArrowDown`) often miss contextual `aria-label`s. In dynamic lists, these labels must include the specific item name to provide meaningful context to screen reader users. Redundant screen reader announcements for the icons themselves can be prevented with `aria-hidden="true"`.
+**Action:** When adding or updating icon-only action buttons in mapped lists, always generate dynamic `aria-label`s based on the specific item context and explicitly set `aria-hidden="true"` on the nested `lucide-react` icon elements.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,6 @@
+import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardPageBadge from "@/components/dashboard/DashboardPageBadge";
@@ -26,14 +29,11 @@ import { toast } from "@/components/ui/use-toast";
 import { useDashboardCurrentUser } from "@/hooks/use-dashboard-current-user";
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences";
 import { usePageMeta } from "@/hooks/use-page-meta";
+import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
-import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { formatDateTime } from "@/lib/date";
 import type { OperationalAlertsResponse } from "@/types/operational-alerts";
-import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 type DashboardPost = {
   id: string;
@@ -1409,16 +1409,18 @@ const Dashboard = () => {
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para baixo`}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label`s to the `ArrowUp` and `ArrowDown` icon-only buttons in the Dashboard widget customization modal, and set `aria-hidden="true"` on the icons themselves.

🎯 **Why:** Icon-only buttons lack accessible names by default, making them unreadable or confusing for screen reader users. In a dynamic list like the widget reordering modal, screen reader users wouldn't know *which* widget the button was moving without dynamic labels.

📸 **Before/After:**
*(Visual change is purely structural and accessible; no UI screenshots necessary)*

♿ **Accessibility:**
- Added `aria-label={"Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima"}` and `para baixo` to clarify the button's purpose and target.
- Added `aria-hidden="true"` to the `lucide-react` SVG elements to ensure screen readers read only the `aria-label` and don't announce redundant, meaningless graphical elements.

---
*PR created automatically by Jules for task [4850620646582487616](https://jules.google.com/task/4850620646582487616) started by @Gavuriiru*