### PR TITLE
🎨 Palette: Add ARIA labels to Dashboard Settings action buttons

### DIFF
--- a/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
@@ -1,3 +1,5 @@
+import { Plus, Trash2 } from "lucide-react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import { Input } from "@/components/dashboard/dashboard-form-controls";
 import {
   dashboardStrongFocusFieldClassName,
@@ -5,14 +7,12 @@ import {
   dashboardStrongFocusTriggerClassName,
   dashboardStrongSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -50,6 +50,7 @@ export const DashboardSettingsDownloadsTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar nova fonte de download"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -69,7 +70,7 @@ export const DashboardSettingsDownloadsTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 
@@ -183,6 +184,7 @@ export const DashboardSettingsDownloadsTab = () => {
                       <DashboardActionButton
                         type="button"
                         size="icon"
+                        aria-label={`Excluir fonte de download ${source.label || "sem nome"}`}
                         className={responsiveSvgCardMobileRemoveButtonClass}
                         onClick={() =>
                           setSettings((prev) => ({
@@ -194,13 +196,14 @@ export const DashboardSettingsDownloadsTab = () => {
                           }))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
                   <DashboardActionButton
                     type="button"
                     size="icon"
+                    aria-label={`Excluir fonte de download ${source.label || "sem nome"}`}
                     className={responsiveSvgCardDesktopRemoveButtonClass}
                     onClick={() =>
                       setSettings((prev) => ({
@@ -212,7 +215,7 @@ export const DashboardSettingsDownloadsTab = () => {
                       }))
                     }
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
-import { Card, CardContent } from "@/components/ui/card";
-import { TabsContent } from "@/components/ui/tabs";
 import { Download, Plus, Save, Trash2 } from "lucide-react";
 import type { UIEvent } from "react";
 import { useState } from "react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Card, CardContent } from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -93,7 +93,7 @@ export const DashboardSettingsTranslationsTab = () => {
                 onClick={() => syncAniListTerms()}
                 disabled={isSyncingAniList}
               >
-                <Download className="h-4 w-4" />
+                <Download className="h-4 w-4" aria-hidden="true" />
                 {isSyncingAniList ? "Importando..." : "Importar AniList"}
               </DashboardActionButton>
               <DashboardActionButton
@@ -106,7 +106,7 @@ export const DashboardSettingsTranslationsTab = () => {
                 }}
                 disabled={!hasResolvedTranslations || isSavingTranslations}
               >
-                <Save className="h-4 w-4" />
+                <Save className="h-4 w-4" aria-hidden="true" />
                 {isSavingTranslations ? "Salvando..." : "Salvar traduções"}
               </DashboardActionButton>
             </div>
@@ -126,6 +126,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar nova tag"
                 onClick={() => {
                   const value = newTag.trim();
                   if (!value || tagTranslations[value] !== undefined) {
@@ -135,7 +136,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewTag("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -181,6 +182,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Excluir tradução de tag ${tag}`}
                             onClick={() =>
                               setTagTranslations((prev) => {
                                 const next = { ...prev };
@@ -189,7 +191,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -218,7 +220,7 @@ export const DashboardSettingsTranslationsTab = () => {
                 onClick={() => syncAniListTerms()}
                 disabled={isSyncingAniList}
               >
-                <Download className="h-4 w-4" />
+                <Download className="h-4 w-4" aria-hidden="true" />
                 {isSyncingAniList ? "Importando..." : "Importar AniList"}
               </DashboardActionButton>
               <DashboardActionButton
@@ -231,7 +233,7 @@ export const DashboardSettingsTranslationsTab = () => {
                 }}
                 disabled={!hasResolvedTranslations || isSavingTranslations}
               >
-                <Save className="h-4 w-4" />
+                <Save className="h-4 w-4" aria-hidden="true" />
                 {isSavingTranslations ? "Salvando..." : "Salvar traduções"}
               </DashboardActionButton>
             </div>
@@ -251,6 +253,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar novo gênero"
                 onClick={() => {
                   const value = newGenre.trim();
                   if (!value || genreTranslations[value] !== undefined) {
@@ -260,7 +263,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewGenre("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -317,6 +320,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Excluir tradução de gênero ${genre}`}
                             onClick={() =>
                               setGenreTranslations((prev) => {
                                 const next = { ...prev };
@@ -325,7 +329,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -357,7 +361,7 @@ export const DashboardSettingsTranslationsTab = () => {
               }}
               disabled={!hasResolvedTranslations || isSavingTranslations}
             >
-              <Save className="h-4 w-4" />
+              <Save className="h-4 w-4" aria-hidden="true" />
               {isSavingTranslations ? "Salvando..." : "Salvar traduções"}
             </DashboardActionButton>
           </div>
@@ -376,6 +380,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar novo cargo"
                 onClick={() => {
                   const value = newStaffRole.trim();
                   if (!value || staffRoleTranslations[value] !== undefined) {
@@ -385,7 +390,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewStaffRole("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -448,6 +453,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Excluir tradução de cargo ${role}`}
                             onClick={() =>
                               setStaffRoleTranslations((prev) => {
                                 const next = { ...prev };
@@ -456,7 +462,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to the icon-only "Add" and "Delete" action buttons in the Dashboard Settings (Downloads and Translations tabs). Also added `aria-hidden="true"` to the internal Lucide icons to prevent screen readers from reading them out loud.
🎯 **Why:** To make the Dashboard Settings accessible for screen reader users by giving explicit descriptions to buttons that previously only used icons, without visual descriptions.
📸 **Before/After:** Not applicable (pure HTML attribute changes, zero visual difference).
♿ **Accessibility:**
- Ensures screen readers announce the exact actions (e.g. "Adicionar novo gênero" or "Excluir tradução de gênero Action").
- Uses `aria-hidden="true"` on inner `<Plus>`, `<Trash2>`, `<Download>`, and `<Save>` icons to prevent redundant or noisy screen reader announcements.

---
*PR created automatically by Jules for task [6624997079555046383](https://jules.google.com/task/6624997079555046383) started by @Gavuriiru*