### PR TITLE
🔒 Sentinel: [HIGH] Fix Host Header Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Raw HTML strings were assigned to `innerHTML` sinks without sanitization within `src/lexical-playground/nodes/ImageNode.tsx` and `src/lexical-playground/hooks/useReport.ts`.
 **Learning:** Even within an encapsulated rich-text editor setup or helper hooks, directly passing HTML strings to `innerHTML` exposes an XSS risk if those strings can be populated with user content.
 **Prevention:** Always sanitize strings with `DOMPurify.sanitize` (using strict profiles like `{ USE_PROFILES: { html: true } }` where appropriate) before rendering them via `innerHTML` or `dangerouslySetInnerHTML`.
+## 2026-05-29 - [Host Header Injection] Mitigating spoofed X-Forwarded-Host headers
+
+**Vulnerability:** The application was manually parsing the `X-Forwarded-Host` header in `server/lib/pwa-bootstrap-policy.js` to determine the request hostname. This could allow an attacker to spoof the host header and bypass checks or cause unexpected behavior.
+**Learning:** Relying on manual parsing of `X-Forwarded-Host` is risky. Frameworks like Express provide built-in, secure mechanisms for resolving the host header when `trust proxy` is configured correctly, which is the default in this codebase.
+**Prevention:** Rely on framework-level hostname resolution (e.g., Express's `req.hostname`) which respects `trust proxy` settings, rather than manually parsing the `X-Forwarded-Host` header.

--- a/server/lib/pwa-bootstrap-policy.js
+++ b/server/lib/pwa-bootstrap-policy.js
@@ -24,10 +24,8 @@ export const resolveBootstrapPwaRequestHostname = (req) => {
     return requestHostname;
   }
 
-  const rawForwardedHost = String(req?.headers?.["x-forwarded-host"] || "")
-    .split(",")[0]
-    .trim();
-  const rawHost = rawForwardedHost || String(req?.headers?.host || "").trim();
+  // Fallback for non-Express environments (e.g. basic HTTP servers, test environments)
+  const rawHost = String(req?.headers?.host || "").trim();
   if (!rawHost) {
     return "";
   }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application manually parsed the `X-Forwarded-Host` header, which is susceptible to Host Header Injection attacks if the reverse proxy isn't strictly validating or sanitizing it.
🎯 Impact: Attackers could spoof the host header, potentially leading to poisoned caches, password reset poisoning (if applicable), or unexpected routing behavior depending on how the hostname is used down the line.
🔧 Fix: Relied on Express's secure `req.hostname` property, which correctly and securely handles forwarded headers when `trust proxy` is enabled. Added a safe fallback to the standard `Host` header for non-Express environments.
✅ Verification: Ran `npx vitest run src/server/pwa-bootstrap-policy.test.ts` to ensure all original tests pass, validating that loopback requests and normal hostname resolution still work correctly.

---
*PR created automatically by Jules for task [17594444612674442721](https://jules.google.com/task/17594444612674442721) started by @Gavuriiru*