### PR TITLE
🎨 Palette: Adicionar labels acessíveis aos botões de reordenar widgets

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2024-05-30 - Added ARIA labels to dashboard widget reordering buttons
+**Learning:** For icon-only buttons in mapped loops (like dashboard custom widgets), generic `aria-label`s are not sufficient. Using dynamic ARIA labels (e.g., `Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`) provides better context to screen readers. Also, explicitly adding `aria-hidden="true"` to nested icon SVG components prevents redundant screen reader announcements.
+**Action:** When creating icon-only buttons within lists or mapped arrays, inject item-specific context into the `aria-label` and remember to hide the nested icon element with `aria-hidden="true"`.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,6 @@
+import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardPageBadge from "@/components/dashboard/DashboardPageBadge";
@@ -26,14 +29,11 @@ import { toast } from "@/components/ui/use-toast";
 import { useDashboardCurrentUser } from "@/hooks/use-dashboard-current-user";
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences";
 import { usePageMeta } from "@/hooks/use-page-meta";
+import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
-import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { formatDateTime } from "@/lib/date";
 import type { OperationalAlertsResponse } from "@/types/operational-alerts";
-import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 type DashboardPost = {
   id: string;
@@ -1409,16 +1409,18 @@ const Dashboard = () => {
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para baixo`}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"


### PR DESCRIPTION
💡 What: Added dynamic `aria-label`s to the up/down arrow buttons used for reordering dashboard widgets in the customization modal, and added `aria-hidden="true"` to the `ArrowUp` and `ArrowDown` SVG icons.
🎯 Why: These buttons were icon-only and lacked descriptive text for screen readers. Using dynamic text (`Mover widget [Nome] para cima/baixo`) allows screen reader users to distinguish which specific widget they are moving.
📸 Before/After: This is a purely structural accessibility change; no visual differences.
♿ Accessibility: Improves keyboard and screen reader accessibility by providing context to previously unlabeled, indistinguishable icon buttons.

---
*PR created automatically by Jules for task [6706300001048995088](https://jules.google.com/task/6706300001048995088) started by @Gavuriiru*