### PR TITLE
🎨 Palette: add ARIA labels to dashboard settings mapping buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2026-06-02 - Consistent aria-labels for internal mappings
+**Learning:** Found that mapping configurations like `DashboardSettingsTranslationsTab.tsx` and `DashboardSettingsSocialLinksTab.tsx` used dynamically rendered icon-only `Trash2` buttons without any ARIA attributes, missing context on what is being deleted.
+**Action:** When working on array/mapping lists, make sure all icon-only action buttons specify `aria-label` targeting the precise index or label (e.g. `Excluir tag ${tag}`), and hide the visual icons with `aria-hidden="true"`.

--- a/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
@@ -1,3 +1,5 @@
+import { Plus, Trash2 } from "lucide-react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import { Input } from "@/components/dashboard/dashboard-form-controls";
 import {
   dashboardStrongFocusFieldClassName,
@@ -5,14 +7,12 @@ import {
   dashboardStrongFocusTriggerClassName,
   dashboardStrongSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,

--- a/src/components/dashboard/settings/DashboardSettingsGeneralTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsGeneralTab.tsx
@@ -1,3 +1,4 @@
+import DashboardFieldStack from "@/components/dashboard/DashboardFieldStack";
 import { Combobox, Input, Textarea } from "@/components/dashboard/dashboard-form-controls";
 import {
   dashboardStrongFocusFieldClassName,
@@ -5,7 +6,6 @@ import {
   dashboardStrongFocusTriggerClassName,
   dashboardStrongSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
-import DashboardFieldStack from "@/components/dashboard/DashboardFieldStack";
 import { Card, CardContent } from "@/components/ui/card";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";

--- a/src/components/dashboard/settings/DashboardSettingsLayoutTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsLayoutTab.tsx
@@ -1,14 +1,14 @@
-import { Combobox, Input, Textarea } from "@/components/dashboard/dashboard-form-controls";
+import { GripVertical, Link2, Plus, Trash2 } from "lucide-react";
+import { useMemo } from "react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardFieldStack from "@/components/dashboard/DashboardFieldStack";
+import { Combobox, Input, Textarea } from "@/components/dashboard/dashboard-form-controls";
 import ReorderControls from "@/components/ReorderControls";
 import { Card, CardContent } from "@/components/ui/card";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
 import { navbarIconOptions } from "@/lib/navbar-icons";
-import { GripVertical, Link2, Plus, Trash2 } from "lucide-react";
-import { useMemo } from "react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,

--- a/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Plus, Save, Trash2 } from "lucide-react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Save, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -54,7 +54,7 @@ export const DashboardSettingsSocialLinksTab = () => {
                   ])
                 }
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
                 Adicionar
               </DashboardActionButton>
               <DashboardActionButton
@@ -67,7 +67,7 @@ export const DashboardSettingsSocialLinksTab = () => {
                 }}
                 disabled={!hasResolvedLinkTypes || isSavingLinkTypes}
               >
-                <Save className="h-4 w-4" />
+                <Save className="h-4 w-4" aria-hidden="true" />
                 {isSavingLinkTypes ? "Salvando..." : "Salvar"}
               </DashboardActionButton>
             </div>
@@ -133,22 +133,24 @@ export const DashboardSettingsSocialLinksTab = () => {
                       <DashboardActionButton
                         type="button"
                         size="icon"
+                        aria-label={`Excluir rede ${link.label || index + 1}`}
                         className={responsiveSvgCardMobileRemoveButtonClass}
                         onClick={() =>
                           setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
                   <DashboardActionButton
                     type="button"
                     size="icon"
+                    aria-label={`Excluir rede ${link.label || index + 1}`}
                     className={responsiveSvgCardDesktopRemoveButtonClass}
                     onClick={() => setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))}
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -37,6 +37,7 @@ export const DashboardSettingsTeamTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar função"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -51,7 +52,7 @@ export const DashboardSettingsTeamTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 
@@ -92,6 +93,7 @@ export const DashboardSettingsTeamTab = () => {
                 <DashboardActionButton
                   type="button"
                   size="icon"
+                  aria-label={`Excluir função ${role.label || index + 1}`}
                   className={responsiveCompactRowDeleteButtonClass}
                   onClick={() =>
                     setSettings((prev) => ({
@@ -100,7 +102,7 @@ export const DashboardSettingsTeamTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}

--- a/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
-import { Card, CardContent } from "@/components/ui/card";
-import { TabsContent } from "@/components/ui/tabs";
 import { Download, Plus, Save, Trash2 } from "lucide-react";
 import type { UIEvent } from "react";
 import { useState } from "react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Card, CardContent } from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -93,7 +93,7 @@ export const DashboardSettingsTranslationsTab = () => {
                 onClick={() => syncAniListTerms()}
                 disabled={isSyncingAniList}
               >
-                <Download className="h-4 w-4" />
+                <Download className="h-4 w-4" aria-hidden="true" />
                 {isSyncingAniList ? "Importando..." : "Importar AniList"}
               </DashboardActionButton>
               <DashboardActionButton
@@ -106,7 +106,7 @@ export const DashboardSettingsTranslationsTab = () => {
                 }}
                 disabled={!hasResolvedTranslations || isSavingTranslations}
               >
-                <Save className="h-4 w-4" />
+                <Save className="h-4 w-4" aria-hidden="true" />
                 {isSavingTranslations ? "Salvando..." : "Salvar traduções"}
               </DashboardActionButton>
             </div>
@@ -126,6 +126,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar tag"
                 onClick={() => {
                   const value = newTag.trim();
                   if (!value || tagTranslations[value] !== undefined) {
@@ -135,7 +136,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewTag("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -181,6 +182,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Excluir tag ${tag}`}
                             onClick={() =>
                               setTagTranslations((prev) => {
                                 const next = { ...prev };
@@ -189,7 +191,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -218,7 +220,7 @@ export const DashboardSettingsTranslationsTab = () => {
                 onClick={() => syncAniListTerms()}
                 disabled={isSyncingAniList}
               >
-                <Download className="h-4 w-4" />
+                <Download className="h-4 w-4" aria-hidden="true" />
                 {isSyncingAniList ? "Importando..." : "Importar AniList"}
               </DashboardActionButton>
               <DashboardActionButton
@@ -231,7 +233,7 @@ export const DashboardSettingsTranslationsTab = () => {
                 }}
                 disabled={!hasResolvedTranslations || isSavingTranslations}
               >
-                <Save className="h-4 w-4" />
+                <Save className="h-4 w-4" aria-hidden="true" />
                 {isSavingTranslations ? "Salvando..." : "Salvar traduções"}
               </DashboardActionButton>
             </div>
@@ -251,6 +253,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar gênero"
                 onClick={() => {
                   const value = newGenre.trim();
                   if (!value || genreTranslations[value] !== undefined) {
@@ -260,7 +263,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewGenre("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -317,6 +320,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Excluir gênero ${genre}`}
                             onClick={() =>
                               setGenreTranslations((prev) => {
                                 const next = { ...prev };
@@ -325,7 +329,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -357,7 +361,7 @@ export const DashboardSettingsTranslationsTab = () => {
               }}
               disabled={!hasResolvedTranslations || isSavingTranslations}
             >
-              <Save className="h-4 w-4" />
+              <Save className="h-4 w-4" aria-hidden="true" />
               {isSavingTranslations ? "Salvando..." : "Salvar traduções"}
             </DashboardActionButton>
           </div>
@@ -376,6 +380,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar cargo"
                 onClick={() => {
                   const value = newStaffRole.trim();
                   if (!value || staffRoleTranslations[value] !== undefined) {
@@ -385,7 +390,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewStaffRole("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -448,6 +453,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Excluir cargo ${role}`}
                             onClick={() =>
                               setStaffRoleTranslations((prev) => {
                                 const next = { ...prev };
@@ -456,7 +462,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>

--- a/src/components/dashboard/settings/shared.tsx
+++ b/src/components/dashboard/settings/shared.tsx
@@ -1,7 +1,3 @@
-import { dashboardPageLayoutTokens } from "@/components/dashboard/dashboard-page-tokens";
-import { type DashboardSettingsLinkTypeItem } from "@/lib/dashboard-settings-cache";
-import { DEFAULT_SITE_SHARE_IMAGE_ALT, resolveAssetAltText } from "@/lib/image-alt";
-import type { SiteSettings } from "@/types/site-settings";
 import {
   BadgeCheck,
   Camera,
@@ -25,6 +21,10 @@ import {
   Video,
   X,
 } from "lucide-react";
+import { dashboardPageLayoutTokens } from "@/components/dashboard/dashboard-page-tokens";
+import { type DashboardSettingsLinkTypeItem } from "@/lib/dashboard-settings-cache";
+import { DEFAULT_SITE_SHARE_IMAGE_ALT, resolveAssetAltText } from "@/lib/image-alt";
+import type { SiteSettings } from "@/types/site-settings";
 import {
   getProjectReaderPresetByType,
   mergeProjectReaderConfig,

--- a/src/components/dashboard/settings/use-dashboard-settings-autosave.ts
+++ b/src/components/dashboard/settings/use-dashboard-settings-autosave.ts
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { toast } from "@/components/ui/use-toast";
 import {
   autosaveRuntimeConfig,
@@ -11,13 +12,12 @@ import { apiFetch } from "@/lib/api-client";
 import { applyBeforeUnloadCompatibility } from "@/lib/before-unload";
 import { writeDashboardSettingsCache } from "@/lib/dashboard-settings-cache";
 import type { SiteSettings } from "@/types/site-settings";
-import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   type LinkTypeItem,
   normalizeDefaultShareImageSettings,
   normalizeLinkTypeId,
-  sanitizeReaderProjectTypesForDashboardSave,
   type SettingsTabKey,
+  sanitizeReaderProjectTypesForDashboardSave,
   type TranslationsPayload,
 } from "./shared";
 

--- a/src/components/dashboard/settings/use-dashboard-settings-loading.ts
+++ b/src/components/dashboard/settings/use-dashboard-settings-loading.ts
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "@/components/ui/use-toast";
 import { defaultSettings, mergeSettings } from "@/hooks/site-settings-context";
 import { useDashboardRefreshToast } from "@/hooks/use-dashboard-refresh-toast";
@@ -7,7 +8,6 @@ import {
   writeDashboardSettingsCache,
 } from "@/lib/dashboard-settings-cache";
 import type { SiteSettings } from "@/types/site-settings";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { type LinkTypeItem, normalizeDefaultShareImageSettings } from "./shared";
 
 type UseDashboardSettingsLoadingOptions = {

--- a/src/components/dashboard/settings/use-dashboard-settings-media.ts
+++ b/src/components/dashboard/settings/use-dashboard-settings-media.ts
@@ -1,8 +1,8 @@
+import { type Dispatch, type SetStateAction, useCallback, useMemo, useState } from "react";
 import { toast } from "@/components/ui/use-toast";
 import { uploadDashboardImageAsset } from "@/lib/dashboard-upload-assets";
 import { DEFAULT_SITE_SHARE_IMAGE_ALT, resolveAssetAltText } from "@/lib/image-alt";
 import type { SiteSettings } from "@/types/site-settings";
-import { type Dispatch, type SetStateAction, useCallback, useMemo, useState } from "react";
 import {
   addIconCacheBust,
   type LinkTypeItem,

--- a/src/components/dashboard/settings/use-dashboard-settings-resource.ts
+++ b/src/components/dashboard/settings/use-dashboard-settings-resource.ts
@@ -1,8 +1,8 @@
+import { type DragEvent, useCallback, useMemo, useState } from "react";
 import { useDashboardSettingsAutosave } from "@/components/dashboard/settings/use-dashboard-settings-autosave";
 import { useDashboardSettingsLoading } from "@/components/dashboard/settings/use-dashboard-settings-loading";
 import { useDashboardSettingsQuerySync } from "@/components/dashboard/settings/use-dashboard-settings-query-sync";
 import type { SiteSettings } from "@/types/site-settings";
-import { type DragEvent, useCallback, useMemo, useState } from "react";
 import {
   getProjectReaderPresetByType,
   mergeProjectReaderConfig,


### PR DESCRIPTION
💡 What: Added `aria-label`s to dynamically mapped icon-only actions (like "Add" or "Trash2") within the dashboard settings tabs (Team, Translations, Social Links), and appended `aria-hidden="true"` to their respective nested `lucide-react` icons.
🎯 Why: To provide correct context to screen reader users about *which* specific item is being targeted for deletion/addition when navigating complex configuration mapping lists.
📸 Before/After: Not a visual change.
♿ Accessibility: Ensures that screen readers announce "Excluir tag Ação" instead of just encountering an unlabeled button. Hides the literal SVG icons so they are not redundantly read.

---
*PR created automatically by Jules for task [1253882536326327793](https://jules.google.com/task/1253882536326327793) started by @Gavuriiru*