### PR TITLE
🎨 Palette: Add context-aware ARIA labels to dashboard settings add buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2025-02-23 - Missing ARIA labels in dynamic form arrays
+**Learning:** The application uses `DashboardActionButton` with `Plus` SVGs for adding items in dynamically generated list settings (like navbar links, footer columns, etc.). These SVGs are typically decorative but weren't marked with `aria-hidden='true'`, and the buttons themselves lacked `aria-label`s, causing them to be completely unannounced to screen readers.
+**Action:** Always verify that 'Add' or 'Create' icon-only buttons in array map contexts have contextually descriptive Portuguese `aria-label`s (e.g., 'Adicionar tag', 'Adicionar coluna') and explicitly set `aria-hidden='true'` on the child icon components.

--- a/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
@@ -1,3 +1,5 @@
+import { Plus, Trash2 } from "lucide-react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import { Input } from "@/components/dashboard/dashboard-form-controls";
 import {
   dashboardStrongFocusFieldClassName,
@@ -5,14 +7,12 @@ import {
   dashboardStrongFocusTriggerClassName,
   dashboardStrongSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -50,6 +50,7 @@ export const DashboardSettingsDownloadsTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar fonte de download"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -69,7 +70,7 @@ export const DashboardSettingsDownloadsTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 

--- a/src/components/dashboard/settings/DashboardSettingsLayoutTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsLayoutTab.tsx
@@ -1,14 +1,14 @@
-import { Combobox, Input, Textarea } from "@/components/dashboard/dashboard-form-controls";
+import { GripVertical, Link2, Plus, Trash2 } from "lucide-react";
+import { useMemo } from "react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardFieldStack from "@/components/dashboard/DashboardFieldStack";
+import { Combobox, Input, Textarea } from "@/components/dashboard/dashboard-form-controls";
 import ReorderControls from "@/components/ReorderControls";
 import { Card, CardContent } from "@/components/ui/card";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
 import { navbarIconOptions } from "@/lib/navbar-icons";
-import { GripVertical, Link2, Plus, Trash2 } from "lucide-react";
-import { useMemo } from "react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -73,6 +73,7 @@ export const DashboardSettingsLayoutTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar link ao menu"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -83,7 +84,7 @@ export const DashboardSettingsLayoutTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 
@@ -210,6 +211,7 @@ export const DashboardSettingsLayoutTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar coluna"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -220,7 +222,7 @@ export const DashboardSettingsLayoutTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 
@@ -380,6 +382,7 @@ export const DashboardSettingsLayoutTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar rede social"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -397,7 +400,7 @@ export const DashboardSettingsLayoutTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 

--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -37,6 +37,7 @@ export const DashboardSettingsTeamTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar função"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -51,7 +52,7 @@ export const DashboardSettingsTeamTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 

--- a/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
-import { Card, CardContent } from "@/components/ui/card";
-import { TabsContent } from "@/components/ui/tabs";
 import { Download, Plus, Save, Trash2 } from "lucide-react";
 import type { UIEvent } from "react";
 import { useState } from "react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Card, CardContent } from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -126,6 +126,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar tag"
                 onClick={() => {
                   const value = newTag.trim();
                   if (!value || tagTranslations[value] !== undefined) {
@@ -135,7 +136,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewTag("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -251,6 +252,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar gênero"
                 onClick={() => {
                   const value = newGenre.trim();
                   if (!value || genreTranslations[value] !== undefined) {
@@ -260,7 +262,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewGenre("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -376,6 +378,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar cargo"
                 onClick={() => {
                   const value = newStaffRole.trim();
                   if (!value || staffRoleTranslations[value] !== undefined) {
@@ -385,7 +388,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewStaffRole("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>


### PR DESCRIPTION
💡 **What**: Added specific, localized (Portuguese) `aria-label` attributes to the icon-only `Plus` buttons used for adding array items across the dashboard settings tabs (Layout, Team, Downloads, Translations). Additionally, added `aria-hidden="true"` to the `Plus` SVGs themselves to hide them from screen readers now that their parent element announces its intent.

🎯 **Why**: Previously, these buttons provided visual cues via the `Plus` icon but were completely unannounced to screen readers. Users relying on assistive technologies would not know the function of the button when navigating setting arrays (like "Menu links", "Translations", etc.). 

📸 **Before/After**: N/A (Non-visual structural change)

♿ **Accessibility**: Significant improvement for screen reader accessibility; screen readers will now read out precisely what action is being taken (e.g., "Adicionar link ao menu", "Adicionar gênero") rather than skipping over the button or announcing it genericly without context.

---
*PR created automatically by Jules for task [7121525440400535021](https://jules.google.com/task/7121525440400535021) started by @Gavuriiru*