### PR TITLE
🔒 Sentinel: SSRF in OG Image Delivery

### DIFF
--- a/server/lib/institutional-og.js
+++ b/server/lib/institutional-og.js
@@ -159,7 +159,20 @@ export const loadInstitutionalOgBackgroundDataUrl = async ({ backgroundUrl, orig
   if (inputBuffer.length === 0 && /^https?:\/\//i.test(normalizedBackgroundUrl)) {
     try {
       const url = new URL(normalizedBackgroundUrl);
-      if (url.protocol === "https:" || url.protocol === "http:") {
+      const hostname = String(url.hostname || "")
+        .trim()
+        .toLowerCase();
+      const isBlockedHostname =
+        hostname === "localhost" ||
+        hostname.startsWith("127.") ||
+        hostname === "0.0.0.0" ||
+        hostname === "[::1]" ||
+        hostname.startsWith("169.254.") ||
+        hostname.startsWith("192.168.") ||
+        hostname.startsWith("10.") ||
+        /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(hostname);
+
+      if (!isBlockedHostname && (url.protocol === "https:" || url.protocol === "http:")) {
         const response = await fetch(url.toString(), { redirect: "error" });
         if (response.ok) {
           inputBuffer = Buffer.from(await response.arrayBuffer());

--- a/server/lib/project-og-assets.js
+++ b/server/lib/project-og-assets.js
@@ -222,6 +222,21 @@ const loadRemoteArtworkAsset = async (artworkUrl) => {
   if (url.protocol !== "https:" && url.protocol !== "http:") {
     return null;
   }
+  const hostname = String(url.hostname || "")
+    .trim()
+    .toLowerCase();
+  if (
+    hostname === "localhost" ||
+    hostname.startsWith("127.") ||
+    hostname === "0.0.0.0" ||
+    hostname === "[::1]" ||
+    hostname.startsWith("169.254.") ||
+    hostname.startsWith("192.168.") ||
+    hostname.startsWith("10.") ||
+    /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(hostname)
+  ) {
+    return null;
+  }
   try {
     const response = await fetch(url.toString(), { redirect: "error" });
     if (!response.ok) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) when proxying external artwork and background assets (`server/lib/project-og-assets.js` and `server/lib/institutional-og.js`) using `fetch()`. The proxy targets lacked strict validation of internal IP ranges and were susceptible to loopback bypasses (e.g., IPv6 `[::1]`, `127.0.0.0/8`, `0.0.0.0`).
🎯 **Impact:** An attacker could craft specific image paths causing the server backend to perform arbitrary HTTP requests to internal IP addresses or internal services accessible only within the VPC or localhost, leaking data or exploring internal network topology.
🔧 **Fix:** Implemented an IP blocklist check in both endpoints enforcing denial of `localhost`, `127.*`, `0.0.0.0`, `[::1]`, and standard private networking subnets before invoking `fetch`.
✅ **Verification:** Verified via test runs (`remote-image-import.test.ts` and `url-safety.test.ts`) that block private ranges logic succeeds and no regressions occur.

---
*PR created automatically by Jules for task [5964955690209322581](https://jules.google.com/task/5964955690209322581) started by @Gavuriiru*