### PR TITLE
🎨 Palette: Accessible delete buttons in dashboard settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,5 @@
-## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
-**Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
-**Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2025-06-06 - Accessible Icon-Only Delete Buttons in Settings
+
+**Learning:** When using mapped UI components (like `DashboardActionButton` wrapping an icon such as `<Trash2>`) to delete items in a dynamic list, screen readers require specific, contextual `aria-label`s (e.g., `aria-label={"Remover tradução da tag " + tag}`) to distinguish the buttons. Additionally, the nested SVG icon itself should be explicitly hidden with `aria-hidden="true"` so that screen readers don't attempt to announce both the button label and the generic "SVG" or icon element.
+
+**Action:** Whenever implementing icon-only buttons, especially inside lists or tables, ensure the wrapping button receives a clear, dynamically contextual `aria-label` and the inner icon component has `aria-hidden="true"`.

--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -92,6 +92,7 @@ export const DashboardSettingsTeamTab = () => {
                 <DashboardActionButton
                   type="button"
                   size="icon"
+                  aria-label={`Remover função ${role.label || index + 1}`}
                   className={responsiveCompactRowDeleteButtonClass}
                   onClick={() =>
                     setSettings((prev) => ({
@@ -100,7 +101,7 @@ export const DashboardSettingsTeamTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}

--- a/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
-import { Card, CardContent } from "@/components/ui/card";
-import { TabsContent } from "@/components/ui/tabs";
 import { Download, Plus, Save, Trash2 } from "lucide-react";
 import type { UIEvent } from "react";
 import { useState } from "react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Card, CardContent } from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -181,6 +181,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução da tag ${tag}`}
                             onClick={() =>
                               setTagTranslations((prev) => {
                                 const next = { ...prev };
@@ -189,7 +190,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -317,6 +318,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução do gênero ${genre}`}
                             onClick={() =>
                               setGenreTranslations((prev) => {
                                 const next = { ...prev };
@@ -325,7 +327,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -448,6 +450,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução do cargo ${role}`}
                             onClick={() =>
                               setStaffRoleTranslations((prev) => {
                                 const next = { ...prev };
@@ -456,7 +459,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to the icon-only "delete" buttons (`DashboardActionButton`) in the Dashboard Settings (Translations and Team tabs). Also added `aria-hidden="true"` to the nested `<Trash2>` icons.
🎯 **Why:** Icon-only buttons without labels are completely opaque to screen readers. In a mapped list of items (like tags or team roles), a generic label isn't enough; users need to know *which* item they are deleting. This enhancement makes the dashboard more accessible for users relying on assistive technologies.
♿ **Accessibility:**
- Screen readers will now announce exactly what item is being removed (e.g., "Remover tradução da tag shounen").
- The raw SVG icons are hidden from the accessibility tree, preventing redundant or confusing announcements.

---
*PR created automatically by Jules for task [11302800623417565350](https://jules.google.com/task/11302800623417565350) started by @Gavuriiru*