### PR TITLE
🎨 Palette: Add dynamic aria-labels to dashboard reorder buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+
+## 2025-06-07 - Dynamic ARIA Labels for Icon-Only Reorder Buttons
+**Learning:** Found ArrowUp/ArrowDown `DashboardActionButton`s used for list reordering that lacked `aria-label`s. Screen readers would just read "Button". Since these buttons apply to specific mapped items, a static label like "Mover para cima" is ambiguous.
+**Action:** Always provide specific, dynamic `aria-label`s (e.g. `aria-label={\`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima\`}`) for icon-only action buttons rendered inside loops/maps to ensure screen reader users can distinguish which item the action applies to. Ensure the inner icon element includes `aria-hidden="true"`.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,6 @@
+import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardPageBadge from "@/components/dashboard/DashboardPageBadge";
@@ -26,14 +29,11 @@ import { toast } from "@/components/ui/use-toast";
 import { useDashboardCurrentUser } from "@/hooks/use-dashboard-current-user";
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences";
 import { usePageMeta } from "@/hooks/use-page-meta";
+import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
-import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { formatDateTime } from "@/lib/date";
 import type { OperationalAlertsResponse } from "@/types/operational-alerts";
-import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 type DashboardPost = {
   id: string;
@@ -1409,16 +1409,18 @@ const Dashboard = () => {
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para baixo`}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label` attributes to the `DashboardActionButton`s used for moving widgets up and down in `src/pages/Dashboard.tsx`. Also added `aria-hidden="true"` to the internal `<ArrowUp>` and `<ArrowDown>` icons.

🎯 **Why:** To improve accessibility. Without dynamic `aria-label`s, screen readers announce these buttons simply as "Button", and even with static labels like "Move up", users wouldn't know *which* widget is being moved.

📸 **Before/After:** No visual changes.

♿ **Accessibility:** Screen reader users can now hear exactly which widget they are moving (e.g. "Mover widget Projetos recentes para cima"). Decorative icons are hidden to prevent redundant announcements.

---
*PR created automatically by Jules for task [17884072988706478824](https://jules.google.com/task/17884072988706478824) started by @Gavuriiru*