### PR TITLE
🎨 Palette: Improve accessibility of team settings buttons

### DIFF
--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -37,6 +37,7 @@ export const DashboardSettingsTeamTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar nova função"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -51,7 +52,7 @@ export const DashboardSettingsTeamTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 
@@ -93,6 +94,7 @@ export const DashboardSettingsTeamTab = () => {
                   type="button"
                   size="icon"
                   className={responsiveCompactRowDeleteButtonClass}
+                  aria-label={`Remover função ${role.label || index + 1}`}
                   onClick={() =>
                     setSettings((prev) => ({
                       ...prev,
@@ -100,7 +102,7 @@ export const DashboardSettingsTeamTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}


### PR DESCRIPTION
💡 **What:** Added missing `aria-label` attributes to the "Adicionar nova função" (Add new role) and "Remover função" (Remove role) icon-only buttons in `DashboardSettingsTeamTab.tsx`. I also added `aria-hidden="true"` to the inner SVG icons to avoid redundant screen reader announcements.
🎯 **Why:** To ensure screen reader users can identify the purpose of these icon-only buttons, improving the overall accessibility of the dashboard settings.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Added specific, contextual ARIA labels (e.g. `Remover função Admin`) for dynamically generated buttons.

---
*PR created automatically by Jules for task [7899268789512351754](https://jules.google.com/task/7899268789512351754) started by @Gavuriiru*