### PR TITLE
🎨 Palette: Add accessible labels to dashboard icon buttons

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,6 @@
+import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardPageBadge from "@/components/dashboard/DashboardPageBadge";
@@ -26,14 +29,11 @@ import { toast } from "@/components/ui/use-toast";
 import { useDashboardCurrentUser } from "@/hooks/use-dashboard-current-user";
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences";
 import { usePageMeta } from "@/hooks/use-page-meta";
+import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
-import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { formatDateTime } from "@/lib/date";
 import type { OperationalAlertsResponse } from "@/types/operational-alerts";
-import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 type DashboardPost = {
   id: string;
@@ -1409,16 +1409,18 @@ const Dashboard = () => {
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para baixo`}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"

--- a/src/pages/DashboardPosts.tsx
+++ b/src/pages/DashboardPosts.tsx
@@ -1,6 +1,26 @@
+import {
+  CalendarDays,
+  Copy,
+  Eye,
+  List as ListIcon,
+  MessageSquare,
+  Plus,
+  RotateCcw,
+  Trash2,
+  UserRound,
+} from "lucide-react";
+import {
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Link, Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
-import ProjectEmbedCard from "@/components/ProjectEmbedCard";
-import UploadPicture from "@/components/UploadPicture";
 import DashboardActionButton, {
   default as Button,
 } from "@/components/dashboard/DashboardActionButton";
@@ -36,6 +56,8 @@ import {
 import LazyImageLibraryDialog from "@/components/lazy/LazyImageLibraryDialog";
 import type { LexicalEditorHandle } from "@/components/lexical/LexicalEditor";
 import LexicalEditorSurface from "@/components/lexical/LexicalEditorSurface";
+import ProjectEmbedCard from "@/components/ProjectEmbedCard";
+import UploadPicture from "@/components/UploadPicture";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import AsyncState from "@/components/ui/async-state";
 import { Badge } from "@/components/ui/badge";
@@ -97,28 +119,6 @@ import { getImageFileNameFromUrl, resolvePostCoverPreview } from "@/lib/post-cov
 import { buildTranslationMap, sortByTranslatedLabel, translateTag } from "@/lib/project-taxonomy";
 import { normalizeUploadVariantUrlKey, type UploadMediaVariantsMap } from "@/lib/upload-variants";
 import type { ContentVersion, EditorialCalendarItem } from "@/types/editorial";
-import {
-  CalendarDays,
-  Copy,
-  Eye,
-  List as ListIcon,
-  MessageSquare,
-  Plus,
-  RotateCcw,
-  Trash2,
-  UserRound,
-} from "lucide-react";
-import {
-  type CSSProperties,
-  type KeyboardEvent as ReactKeyboardEvent,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { Link, Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 const POST_EDITOR_TOOLBAR_STICKY_OFFSET_PX = 5;
 
@@ -2124,7 +2124,12 @@ const DashboardPosts = () => {
                             </DashboardActionButton>
                           ) : null}
                           {editorPublicHref ? (
-                            <DashboardActionButton type="button" size="icon" asChild>
+                            <DashboardActionButton
+                              type="button"
+                              size="icon"
+                              asChild
+                              aria-label="Visualizar postagem"
+                            >
                               <Link target="_blank" rel="noreferrer" to={editorPublicHref}>
                                 <Eye className="h-4 w-4" aria-hidden="true" />
                               </Link>

--- a/src/pages/DashboardProjectsEditor.tsx
+++ b/src/pages/DashboardProjectsEditor.tsx
@@ -1,3 +1,16 @@
+import {
+  Clapperboard,
+  Copy,
+  Eye,
+  FileImage,
+  FileText,
+  type LucideIcon,
+  PencilLine,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton, {
   default as Button,
@@ -16,6 +29,11 @@ import {
   dashboardStrongSurfaceHoverClassName,
   dashboardSubtleSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
+import type {
+  EditorProjectEpisode,
+  ProjectForm,
+  ProjectRecord,
+} from "@/components/dashboard/project-editor/dashboard-projects-editor-types";
 import ProjectEditorDialogShell from "@/components/dashboard/project-editor/ProjectEditorDialogShell";
 import ProjectEditorImageLibraryDialog from "@/components/dashboard/project-editor/ProjectEditorImageLibraryDialog";
 import ProjectEditorImportSection from "@/components/dashboard/project-editor/ProjectEditorImportSection";
@@ -28,11 +46,6 @@ import {
   ProjectEditorConfirmDialog,
   ProjectEditorDeleteDialog,
 } from "@/components/dashboard/project-editor/ProjectEditorSupportDialogs";
-import type {
-  EditorProjectEpisode,
-  ProjectForm,
-  ProjectRecord,
-} from "@/components/dashboard/project-editor/dashboard-projects-editor-types";
 import { DEFAULT_PROJECT_FORMAT_OPTIONS } from "@/components/dashboard/project-editor/project-editor-constants";
 import {
   buildEmptyProjectForm,
@@ -84,19 +97,6 @@ import { resolveEpisodeLookup } from "@/lib/project-episode-key";
 import { isChapterBasedType, isLightNovelType, isMangaType } from "@/lib/project-utils";
 import { buildVolumeCoverKey } from "@/lib/project-volume-cover-key";
 import { reorderItems } from "@/lib/reorder-items";
-import {
-  Clapperboard,
-  Copy,
-  Eye,
-  FileImage,
-  FileText,
-  type LucideIcon,
-  PencilLine,
-  Plus,
-  Trash2,
-} from "lucide-react";
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 const getDedicatedEditorCtaIcon = (projectType?: string | null): LucideIcon => {
   const normalizedType = String(projectType || "").trim();
@@ -1223,22 +1223,26 @@ const DashboardProjectsEditor = () => {
                                   size="icon-sm"
                                   title="Editor dedicado"
                                   asChild
+                                  aria-label={`Abrir editor dedicado de ${project.title}`}
                                 >
-                                  <Link
-                                    to={dedicatedEditorHref}
-                                    aria-label={`Abrir editor dedicado de ${project.title}`}
-                                  >
+                                  <Link to={dedicatedEditorHref}>
                                     <DedicatedEditorIcon className="h-4 w-4" aria-hidden="true" />
                                   </Link>
                                 </DashboardActionButton>
-                                <DashboardActionButton size="icon-sm" title="Visualizar" asChild>
+                                <DashboardActionButton
+                                  size="icon-sm"
+                                  title="Visualizar"
+                                  asChild
+                                  aria-label={`Visualizar projeto ${project.title}`}
+                                >
                                   <Link to={buildProjectPublicHref(project.id)}>
-                                    <Eye className="h-4 w-4" />
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
                                   </Link>
                                 </DashboardActionButton>
                                 <DashboardActionButton
                                   size="icon-sm"
                                   title="Copiar link"
+                                  aria-label={`Copiar link do projeto ${project.title}`}
                                   onClick={() => {
                                     const url = `${window.location.origin}${buildProjectPublicHref(project.id)}`;
                                     navigator.clipboard.writeText(url).catch(() => {
@@ -1251,17 +1255,18 @@ const DashboardProjectsEditor = () => {
                                     });
                                   }}
                                 >
-                                  <Copy className="h-4 w-4" />
+                                  <Copy className="h-4 w-4" aria-hidden="true" />
                                 </DashboardActionButton>
                                 <DashboardActionButton
                                   tone="destructive"
                                   size="icon-sm"
                                   title="Excluir"
+                                  aria-label={`Excluir projeto ${project.title}`}
                                   onClick={() => {
                                     setDeleteTarget(project);
                                   }}
                                 >
-                                  <Trash2 className="h-4 w-4 text-destructive" />
+                                  <Trash2 className="h-4 w-4 text-destructive" aria-hidden="true" />
                                 </DashboardActionButton>
                               </div>
                             </div>


### PR DESCRIPTION
💡 **What:** Added descriptive Portuguese `aria-label`s to various icon-only action buttons across the dashboard (`Dashboard.tsx`, `DashboardPosts.tsx`, `DashboardProjectsEditor.tsx`) and added `aria-hidden="true"` to their internal SVG icons.
🎯 **Why:** Icon-only buttons lack inherent text content, making them inaccessible to screen readers. Adding ARIA labels provides context, and hiding the SVGs prevents redundant announcements.
📸 **Before/After:** No visual change.
♿ **Accessibility:** Screen reader users can now understand the purpose of action buttons like "Mover widget X para cima", "Visualizar projeto", "Copiar link", and "Excluir".

---
*PR created automatically by Jules for task [884141604823618194](https://jules.google.com/task/884141604823618194) started by @Gavuriiru*