### PR TITLE
🎨 Palette: Add missing ARIA labels to dashboard settings buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2026-06-11 - Adding ARIA labels to Trash and Plus Buttons in Dashboard Settings
+**Learning:** Confirmed that across all dashboard settings tabs, the use of `DashboardActionButton` with an icon-only setup for deleting (Trash2) and adding (Plus) items consistently lacks `aria-label`s. Iterating over list elements frequently implies a pattern of missing accessibility descriptors for those actions.
+**Action:** When adding or auditing map-based dynamic lists with action buttons in the Dashboard, explicitly provide an `aria-label` describing both the action and the specific item context (e.g. `Remover coluna do rodapé ${column.title || 'sem nome'}`), and remember to pass `aria-hidden="true"` to the internal Lucide icons.

--- a/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
@@ -1,3 +1,5 @@
+import { Plus, Trash2 } from "lucide-react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import { Input } from "@/components/dashboard/dashboard-form-controls";
 import {
   dashboardStrongFocusFieldClassName,
@@ -5,14 +7,12 @@ import {
   dashboardStrongFocusTriggerClassName,
   dashboardStrongSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -50,6 +50,7 @@ export const DashboardSettingsDownloadsTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar fonte de download"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -69,7 +70,7 @@ export const DashboardSettingsDownloadsTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 
@@ -184,6 +185,7 @@ export const DashboardSettingsDownloadsTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveSvgCardMobileRemoveButtonClass}
+                        aria-label={`Remover fonte de download ${source.label || "sem nome"}`}
                         onClick={() =>
                           setSettings((prev) => ({
                             ...prev,
@@ -194,7 +196,7 @@ export const DashboardSettingsDownloadsTab = () => {
                           }))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
@@ -202,6 +204,7 @@ export const DashboardSettingsDownloadsTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
+                    aria-label={`Remover fonte de download ${source.label || "sem nome"}`}
                     onClick={() =>
                       setSettings((prev) => ({
                         ...prev,
@@ -212,7 +215,7 @@ export const DashboardSettingsDownloadsTab = () => {
                       }))
                     }
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsLayoutTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsLayoutTab.tsx
@@ -1,14 +1,14 @@
-import { Combobox, Input, Textarea } from "@/components/dashboard/dashboard-form-controls";
+import { GripVertical, Link2, Plus, Trash2 } from "lucide-react";
+import { useMemo } from "react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardFieldStack from "@/components/dashboard/DashboardFieldStack";
+import { Combobox, Input, Textarea } from "@/components/dashboard/dashboard-form-controls";
 import ReorderControls from "@/components/ReorderControls";
 import { Card, CardContent } from "@/components/ui/card";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
 import { navbarIconOptions } from "@/lib/navbar-icons";
-import { GripVertical, Link2, Plus, Trash2 } from "lucide-react";
-import { useMemo } from "react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -163,7 +163,7 @@ export const DashboardSettingsLayoutTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}
@@ -252,7 +252,7 @@ export const DashboardSettingsLayoutTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveCompactSelfEndDeleteButtonClass}
-                    aria-label="Remover coluna do footer"
+                    aria-label={`Remover coluna do rodapé ${column.title || "sem nome"}`}
                     onClick={() =>
                       setSettings((prev) => ({
                         ...prev,
@@ -263,7 +263,7 @@ export const DashboardSettingsLayoutTab = () => {
                       }))
                     }
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
                 <div className="grid gap-3">
@@ -320,7 +320,7 @@ export const DashboardSettingsLayoutTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveCompactRowDeleteButtonClass}
-                        aria-label="Remover link da coluna do footer"
+                        aria-label={`Remover link ${link.label || "sem nome"} da coluna`}
                         onClick={() =>
                           setSettings((prev) => {
                             const nextColumns = [...prev.footer.columns];
@@ -338,7 +338,7 @@ export const DashboardSettingsLayoutTab = () => {
                           })
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   ))}
@@ -449,7 +449,7 @@ export const DashboardSettingsLayoutTab = () => {
                         }))
                       }
                     >
-                      <Trash2 className="h-4 w-4" />
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                   </div>
                   <Combobox
@@ -511,7 +511,7 @@ export const DashboardSettingsLayoutTab = () => {
                       }))
                     }
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               </div>
@@ -561,7 +561,7 @@ export const DashboardSettingsLayoutTab = () => {
                         }))
                       }
                     >
-                      <Trash2 className="h-4 w-4" />
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                   </div>
                 ))}

--- a/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Plus, Save, Trash2 } from "lucide-react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Save, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -134,11 +134,12 @@ export const DashboardSettingsSocialLinksTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveSvgCardMobileRemoveButtonClass}
+                        aria-label={`Remover rede social ${link.label || index + 1}`}
                         onClick={() =>
                           setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
@@ -146,9 +147,10 @@ export const DashboardSettingsSocialLinksTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
+                    aria-label={`Remover rede social ${link.label || index + 1}`}
                     onClick={() => setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))}
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -37,6 +37,7 @@ export const DashboardSettingsTeamTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar função"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -51,7 +52,7 @@ export const DashboardSettingsTeamTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 
@@ -93,6 +94,7 @@ export const DashboardSettingsTeamTab = () => {
                   type="button"
                   size="icon"
                   className={responsiveCompactRowDeleteButtonClass}
+                  aria-label={`Remover função ${role.label || "sem nome"}`}
                   onClick={() =>
                     setSettings((prev) => ({
                       ...prev,
@@ -100,7 +102,7 @@ export const DashboardSettingsTeamTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}

--- a/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
-import { Card, CardContent } from "@/components/ui/card";
-import { TabsContent } from "@/components/ui/tabs";
 import { Download, Plus, Save, Trash2 } from "lucide-react";
 import type { UIEvent } from "react";
 import { useState } from "react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Card, CardContent } from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -126,6 +126,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar tag"
                 onClick={() => {
                   const value = newTag.trim();
                   if (!value || tagTranslations[value] !== undefined) {
@@ -135,7 +136,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewTag("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -181,6 +182,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tag ${tag}`}
                             onClick={() =>
                               setTagTranslations((prev) => {
                                 const next = { ...prev };
@@ -189,7 +191,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -251,6 +253,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar gênero"
                 onClick={() => {
                   const value = newGenre.trim();
                   if (!value || genreTranslations[value] !== undefined) {
@@ -260,7 +263,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewGenre("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -317,6 +320,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover gênero ${genre}`}
                             onClick={() =>
                               setGenreTranslations((prev) => {
                                 const next = { ...prev };
@@ -325,7 +329,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -376,6 +380,7 @@ export const DashboardSettingsTranslationsTab = () => {
               <DashboardActionButton
                 type="button"
                 tone="primary"
+                aria-label="Adicionar cargo"
                 onClick={() => {
                   const value = newStaffRole.trim();
                   if (!value || staffRoleTranslations[value] !== undefined) {
@@ -385,7 +390,7 @@ export const DashboardSettingsTranslationsTab = () => {
                   setNewStaffRole("");
                 }}
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </DashboardActionButton>
             </div>
           </div>
@@ -448,6 +453,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover cargo ${role}`}
                             onClick={() =>
                               setStaffRoleTranslations((prev) => {
                                 const next = { ...prev };
@@ -456,7 +462,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label`s to the `Trash2` (delete) and `Plus` (add) icon-only buttons across multiple dashboard settings tabs (Downloads, Layout, Social Links, Team, and Translations). Also appended `aria-hidden="true"` to the internal Lucide React icons.

🎯 **Why:** To ensure screen-reader users understand what action these icon-only buttons perform, and specifically *which* item they are deleting (e.g., "Remover link da navegação Meu Link" instead of a generic "Remover").

📸 **Before/After:** No visual change.

♿ **Accessibility:** This directly fixes multiple instances of missing accessible names for buttons in the DOM, allowing users relying on assistive technologies to effectively navigate and manage dashboard settings without guessing button functions.

---
*PR created automatically by Jules for task [5330519541640523999](https://jules.google.com/task/5330519541640523999) started by @Gavuriiru*