### PR TITLE
🎨 Palette: Add specific ARIA labels to icon-only delete buttons in settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2026-06-12 - Add specific ARIA labels to icon-only delete buttons in dynamic mapped lists
+**Learning:** Icon-only delete buttons inside `.map()` iterations often lack distinct `aria-label` attributes and include screen reader announcements for the icon itself. Using generic labels like 'Remover' makes it hard for users of assistive technologies to distinguish which exact item is being removed.
+**Action:** Always append dynamic properties (e.g., `item.label` or `index + 1`) to the `aria-label` of icon-only action buttons inside loops, and add `aria-hidden="true"` to the nested icon element to prevent redundant announcements.

--- a/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
@@ -1,3 +1,5 @@
+import { Plus, Trash2 } from "lucide-react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import { Input } from "@/components/dashboard/dashboard-form-controls";
 import {
   dashboardStrongFocusFieldClassName,
@@ -5,14 +7,12 @@ import {
   dashboardStrongFocusTriggerClassName,
   dashboardStrongSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -184,6 +184,7 @@ export const DashboardSettingsDownloadsTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveSvgCardMobileRemoveButtonClass}
+                        aria-label={"Remover download " + (source.label || index + 1)}
                         onClick={() =>
                           setSettings((prev) => ({
                             ...prev,
@@ -194,7 +195,7 @@ export const DashboardSettingsDownloadsTab = () => {
                           }))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
@@ -202,6 +203,7 @@ export const DashboardSettingsDownloadsTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
+                    aria-label={"Remover download " + (source.label || index + 1)}
                     onClick={() =>
                       setSettings((prev) => ({
                         ...prev,
@@ -212,7 +214,7 @@ export const DashboardSettingsDownloadsTab = () => {
                       }))
                     }
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Plus, Save, Trash2 } from "lucide-react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Save, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -134,11 +134,12 @@ export const DashboardSettingsSocialLinksTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveSvgCardMobileRemoveButtonClass}
+                        aria-label={"Remover rede social " + (link.label || index + 1)}
                         onClick={() =>
                           setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
@@ -146,9 +147,10 @@ export const DashboardSettingsSocialLinksTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
+                    aria-label={"Remover rede social " + (link.label || index + 1)}
                     onClick={() => setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))}
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -93,6 +93,7 @@ export const DashboardSettingsTeamTab = () => {
                   type="button"
                   size="icon"
                   className={responsiveCompactRowDeleteButtonClass}
+                  aria-label={"Remover função " + (role.label || index + 1)}
                   onClick={() =>
                     setSettings((prev) => ({
                       ...prev,
@@ -100,7 +101,7 @@ export const DashboardSettingsTeamTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}

--- a/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
-import { Card, CardContent } from "@/components/ui/card";
-import { TabsContent } from "@/components/ui/tabs";
 import { Download, Plus, Save, Trash2 } from "lucide-react";
 import type { UIEvent } from "react";
 import { useState } from "react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Card, CardContent } from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -181,6 +181,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={"Remover tradução de tag " + tag}
                             onClick={() =>
                               setTagTranslations((prev) => {
                                 const next = { ...prev };
@@ -189,7 +190,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -317,6 +318,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={"Remover tradução de gênero " + genre}
                             onClick={() =>
                               setGenreTranslations((prev) => {
                                 const next = { ...prev };
@@ -325,7 +327,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -448,6 +450,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={"Remover tradução de cargo " + role}
                             onClick={() =>
                               setStaffRoleTranslations((prev) => {
                                 const next = { ...prev };
@@ -456,7 +459,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label`s appended with dynamic object attributes or iterators to icon-only action buttons containing only icons within mapped loops in internal settings components, and added `aria-hidden="true"` to nested Trash icons.
🎯 **Why:** Previously, Screen reader users would hear an unhelpful, generic 'Remover' alongside redundant announcements of the underlying svg graphic, without clarifying which specific row was being deleted. This fix ensures users of assistive technologies know precisely which configuration row their action will target.
♿ **Accessibility:** Yes, adds specific label references per row and silences meaningless graphical elements for screen readers.

---
*PR created automatically by Jules for task [4817054853720258836](https://jules.google.com/task/4817054853720258836) started by @Gavuriiru*