### PR TITLE
🎨 Palette: Add dynamic ARIA labels to icon-only buttons in settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2024-05-19 - Dashboard Settings Action Buttons A11y
+**Learning:** Icon-only buttons used inside dynamic lists (like `DashboardSettingsTeamTab` or `DashboardSettingsSocialLinksTab`) frequently omit `aria-label`s, which makes them inaccessible to screen readers. Further, nested Lucide icons inside these buttons need `aria-hidden="true"` so they aren't redundantly announced.
+**Action:** When adding or auditing icon-only buttons (`DashboardActionButton size="icon"`), always include an `aria-label`. For mapped items, construct a dynamic label (e.g., `Remover rede ${link.label}`) and strictly add `aria-hidden="true"` to the inner Lucide icon.

--- a/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Plus, Save, Trash2 } from "lucide-react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Save, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -54,7 +54,7 @@ export const DashboardSettingsSocialLinksTab = () => {
                   ])
                 }
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
                 Adicionar
               </DashboardActionButton>
               <DashboardActionButton
@@ -67,7 +67,7 @@ export const DashboardSettingsSocialLinksTab = () => {
                 }}
                 disabled={!hasResolvedLinkTypes || isSavingLinkTypes}
               >
-                <Save className="h-4 w-4" />
+                <Save className="h-4 w-4" aria-hidden="true" />
                 {isSavingLinkTypes ? "Salvando..." : "Salvar"}
               </DashboardActionButton>
             </div>
@@ -134,11 +134,12 @@ export const DashboardSettingsSocialLinksTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveSvgCardMobileRemoveButtonClass}
+                        aria-label={`Remover rede ${link.label || index + 1}`}
                         onClick={() =>
                           setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
@@ -146,9 +147,10 @@ export const DashboardSettingsSocialLinksTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
+                    aria-label={`Remover rede ${link.label || index + 1}`}
                     onClick={() => setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))}
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -37,6 +37,7 @@ export const DashboardSettingsTeamTab = () => {
             </div>
             <DashboardActionButton
               type="button"
+              aria-label="Adicionar nova função"
               onClick={() =>
                 setSettings((prev) => ({
                   ...prev,
@@ -51,7 +52,7 @@ export const DashboardSettingsTeamTab = () => {
                 }))
               }
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </DashboardActionButton>
           </div>
 
@@ -93,6 +94,7 @@ export const DashboardSettingsTeamTab = () => {
                   type="button"
                   size="icon"
                   className={responsiveCompactRowDeleteButtonClass}
+                  aria-label={`Remover função ${role.label || index + 1}`}
                   onClick={() =>
                     setSettings((prev) => ({
                       ...prev,
@@ -100,7 +102,7 @@ export const DashboardSettingsTeamTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}


### PR DESCRIPTION
💡 **What**: Added dynamic `aria-label` attributes to the icon-only "Delete" buttons in the Team and Social Links settings tabs, and added `aria-hidden="true"` to their respective nested Lucide icons.
🎯 **Why**: Previously, these buttons were inaccessible to screen reader users because they only contained icons without textual alternatives. The dynamic labels (e.g. "Remover rede X" or "Remover função Y") provide context, while hiding the decorative icons prevents redundant or confusing announcements.
♿ **Accessibility**: Improves keyboard navigation and screen reader support for key administrative actions.

---
*PR created automatically by Jules for task [2522630435247716599](https://jules.google.com/task/2522630435247716599) started by @Gavuriiru*