### PR TITLE
🎨 Palette: Add dynamic ARIA labels to dashboard widget move buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2025-02-28 - Add ARIA Labels to Dashboard Widget Move Buttons
+**Learning:** Icon-only buttons used for widget reordering within the dashboard lacked descriptive ARIA labels, making it difficult for screen reader users to understand their function. In dynamic lists, static labels are insufficient; labels must incorporate dynamic content (like the widget name) to distinguish between items.
+**Action:** Always ensure that icon-only buttons (`DashboardActionButton` with Lucide icons) in dynamic mapped lists include dynamic `aria-label`s (e.g., ``aria-label={`Mover widget ${widgetName} para cima`}``) in Portuguese. Additionally, add `aria-hidden="true"` to the internal icon to prevent redundant readouts.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,6 @@
+import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardPageBadge from "@/components/dashboard/DashboardPageBadge";
@@ -26,14 +29,11 @@ import { toast } from "@/components/ui/use-toast";
 import { useDashboardCurrentUser } from "@/hooks/use-dashboard-current-user";
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences";
 import { usePageMeta } from "@/hooks/use-page-meta";
+import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
-import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { formatDateTime } from "@/lib/date";
 import type { OperationalAlertsResponse } from "@/types/operational-alerts";
-import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 type DashboardPost = {
   id: string;
@@ -1409,16 +1409,18 @@ const Dashboard = () => {
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para baixo`}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label`s to the `DashboardActionButton`s used for moving custom draft widgets up and down in the dashboard configuration modal.
🎯 **Why:** To improve accessibility for screen reader users by providing clear context for icon-only buttons, specifying exactly which widget the action applies to.
📸 **Before/After:** Not applicable (purely non-visual change).
♿ **Accessibility:**
- Added `aria-label` attribute (e.g., `"Mover widget Projetos para cima"`) to clarify the button's action and target.
- Added `aria-hidden="true"` to the inner `ArrowUp` and `ArrowDown` Lucide icons to prevent screen readers from reading generic SVG titles or descriptions redundantly.

---
*PR created automatically by Jules for task [7124030550910162454](https://jules.google.com/task/7124030550910162454) started by @Gavuriiru*