### PR TITLE
🎨 Palette: Add ARIA labels to dashboard settings icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## $(date +%Y-%m-%d) - Add missing ARIA labels to dashboard settings icon buttons
+**Learning:** Found an accessibility issue pattern specific to this app's components where `DashboardActionButton`s configured with `size="icon"` (typically used for "Delete" or "Remove" actions with Lucide icons) across various settings tabs lacked `aria-label`s, rendering them inscrutable to screen readers.
+**Action:** When adding or modifying `DashboardActionButton`s or other icon-only buttons in the application, ensure an explicit `aria-label` attribute in Portuguese (e.g., `aria-label="Remover tradução de tag"`) is consistently provided.

--- a/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
@@ -1,3 +1,5 @@
+import { Plus, Trash2 } from "lucide-react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import { Input } from "@/components/dashboard/dashboard-form-controls";
 import {
   dashboardStrongFocusFieldClassName,
@@ -5,14 +7,12 @@ import {
   dashboardStrongFocusTriggerClassName,
   dashboardStrongSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -183,6 +183,7 @@ export const DashboardSettingsDownloadsTab = () => {
                       <DashboardActionButton
                         type="button"
                         size="icon"
+                        aria-label="Remover fonte de download"
                         className={responsiveSvgCardMobileRemoveButtonClass}
                         onClick={() =>
                           setSettings((prev) => ({
@@ -201,6 +202,7 @@ export const DashboardSettingsDownloadsTab = () => {
                   <DashboardActionButton
                     type="button"
                     size="icon"
+                    aria-label="Remover fonte de download"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
                     onClick={() =>
                       setSettings((prev) => ({

--- a/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Plus, Save, Trash2 } from "lucide-react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Save, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -133,6 +133,7 @@ export const DashboardSettingsSocialLinksTab = () => {
                       <DashboardActionButton
                         type="button"
                         size="icon"
+                        aria-label="Remover rede social"
                         className={responsiveSvgCardMobileRemoveButtonClass}
                         onClick={() =>
                           setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))
@@ -145,6 +146,7 @@ export const DashboardSettingsSocialLinksTab = () => {
                   <DashboardActionButton
                     type="button"
                     size="icon"
+                    aria-label="Remover rede social"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
                     onClick={() => setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))}
                   >

--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -92,6 +92,7 @@ export const DashboardSettingsTeamTab = () => {
                 <DashboardActionButton
                   type="button"
                   size="icon"
+                  aria-label="Remover função da equipe"
                   className={responsiveCompactRowDeleteButtonClass}
                   onClick={() =>
                     setSettings((prev) => ({

--- a/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
-import { Card, CardContent } from "@/components/ui/card";
-import { TabsContent } from "@/components/ui/tabs";
 import { Download, Plus, Save, Trash2 } from "lucide-react";
 import type { UIEvent } from "react";
 import { useState } from "react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Card, CardContent } from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -181,6 +181,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label="Remover tradução de tag"
                             onClick={() =>
                               setTagTranslations((prev) => {
                                 const next = { ...prev };
@@ -317,6 +318,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label="Remover tradução de gênero"
                             onClick={() =>
                               setGenreTranslations((prev) => {
                                 const next = { ...prev };
@@ -448,6 +450,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label="Remover tradução de função da equipe"
                             onClick={() =>
                               setStaffRoleTranslations((prev) => {
                                 const next = { ...prev };


### PR DESCRIPTION
💡 **What:** Added `aria-label`s to multiple icon-only `DashboardActionButton`s across dashboard settings components (`DashboardSettingsDownloadsTab`, `DashboardSettingsTranslationsTab`, `DashboardSettingsSocialLinksTab`, `DashboardSettingsTeamTab`).
🎯 **Why:** Icon-only buttons (like those with `Trash2` or `Plus` icons) without text context are a major accessibility barrier. Screen readers need a descriptive label to announce the button's action to visually impaired users.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen reader users can now understand the specific action of each delete/remove button (e.g., "Remover tradução de tag", "Remover fonte de download").

---
*PR created automatically by Jules for task [3674380467191216044](https://jules.google.com/task/3674380467191216044) started by @Gavuriiru*