### PR TITLE
🎨 Palette: Add dynamic aria-labels to dashboard widget reorder buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2026-06-18 - Added ARIA labels to Dashboard Draft Widget Movers
+**Learning:** Confirmed pattern that icon-only buttons ( using Lucide icons) inside mapped lists/arrays often miss s. Dynamically interpolating the array item's label into the `aria-label` string (e.g. `Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`) is essential so screen reader users know *which* item the action applies to, rather than just hearing generic 'Mover para cima' repeatedly.
+**Action:** Always verify icon-only buttons in  loops have dynamic s that reference the specific item's context.
+## $(date +%Y-%m-%d) - Added ARIA labels to Dashboard Draft Widget Movers
+**Learning:** Confirmed pattern that icon-only buttons (`DashboardActionButton` using Lucide icons) inside mapped lists/arrays often miss `aria-label`s. Dynamically interpolating the array item's label into the `aria-label` string (e.g. `Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`) is essential so screen reader users know *which* item the action applies to, rather than just hearing generic 'Mover para cima' repeatedly.
+**Action:** Always verify icon-only buttons in `.map()` loops have dynamic `aria-label`s that reference the specific item's context.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,6 @@
+import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardPageBadge from "@/components/dashboard/DashboardPageBadge";
@@ -26,14 +29,11 @@ import { toast } from "@/components/ui/use-toast";
 import { useDashboardCurrentUser } from "@/hooks/use-dashboard-current-user";
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences";
 import { usePageMeta } from "@/hooks/use-page-meta";
+import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
-import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { formatDateTime } from "@/lib/date";
 import type { OperationalAlertsResponse } from "@/types/operational-alerts";
-import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 type DashboardPost = {
   id: string;
@@ -1407,18 +1407,20 @@ const Dashboard = () => {
                     <DashboardActionButton
                       type="button"
                       size="icon"
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`}
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp aria-hidden="true" className="h-4 w-4" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para baixo`}
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown aria-hidden="true" className="h-4 w-4" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"


### PR DESCRIPTION
💡 What: Added dynamically generated `aria-label`s to the icon-only "Move Up" and "Move Down" buttons for personalized draft dashboard widgets. Added `aria-hidden="true"` to the inner Lucide SVG icons.

🎯 Why: The buttons were icon-only and rendered in a loop, making it impossible for screen reader users to distinguish which widget a specific action button applied to without contextual `aria-label` strings (e.g. `Mover widget [Widget Name] para cima`).

📸 Before/After: Not a visual change.

♿ Accessibility: Ensures correct pronunciation and context (using Portuguese) for actions inside `.map` loops, and silences redundant DOM icon elements.

---
*PR created automatically by Jules for task [12957903149940758109](https://jules.google.com/task/12957903149940758109) started by @Gavuriiru*