### PR TITLE
🎨 Palette: Add ARIA labels to dashboard widget reorder buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2024-05-18 - Dashboard Action Button ARIA Label Pattern
+**Learning:** Icon-only buttons using `DashboardActionButton` in dynamically mapped elements (like `DASHBOARD_WIDGET_LABELS` in the dashboard) often lack descriptive `aria-label`s. Without dynamic context in the `aria-label`, screen readers will only announce generic text for all mapped buttons, causing confusion.
+**Action:** Always inject specific dynamic state (like the actual widget or item name) into the `aria-label` for mapped icon-only buttons, and apply `aria-hidden="true"` to the inner Lucide icon to prevent screen reader redundancy.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,6 @@
+import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardPageBadge from "@/components/dashboard/DashboardPageBadge";
@@ -26,14 +29,11 @@ import { toast } from "@/components/ui/use-toast";
 import { useDashboardCurrentUser } from "@/hooks/use-dashboard-current-user";
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences";
 import { usePageMeta } from "@/hooks/use-page-meta";
+import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
-import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { formatDateTime } from "@/lib/date";
 import type { OperationalAlertsResponse } from "@/types/operational-alerts";
-import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 type DashboardPost = {
   id: string;
@@ -1409,16 +1409,18 @@ const Dashboard = () => {
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para baixo`}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"


### PR DESCRIPTION
### 💡 What
Added descriptive `aria-label`s with dynamic context to the "Move Up" and "Move Down" icon-only widget reorder buttons in the dashboard customization dialog, and hid the underlying Lucide SVGs from screen readers using `aria-hidden="true"`.

### 🎯 Why
Screen reader users navigating the dashboard customization dialog had no way to distinguish what the up/down arrow buttons did or which widget they applied to, as they lacked any accessible name.

### ♿ Accessibility
- Added `aria-label` dynamically using the widget name from `DASHBOARD_WIDGET_LABELS`.
- Added `aria-hidden="true"` to `<ArrowUp />` and `<ArrowDown />` icons to prevent redundant screen reader announcements.

---
*PR created automatically by Jules for task [831708180275700161](https://jules.google.com/task/831708180275700161) started by @Gavuriiru*