### PR TITLE
🎨 Palette: Improve accessibility of dashboard widget customization buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+
+## 2025-02-27 - Added Aria Labels to Customize Dashboard Buttons
+**Learning:** Found an accessibility issue pattern in mapped loops. Icon-only buttons for dynamic items (like moving widgets) frequently lack distinct `aria-label`s, which makes it hard for screen readers to differentiate what each button controls.
+**Action:** Always ensure that `aria-label`s in mapped loops include dynamic context (e.g. `Mover widget ${label} para cima`) and that nested decorative SVG icons include `aria-hidden="true"`.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,6 @@
+import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import DashboardShell from "@/components/DashboardShell";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import DashboardPageBadge from "@/components/dashboard/DashboardPageBadge";
@@ -26,14 +29,11 @@ import { toast } from "@/components/ui/use-toast";
 import { useDashboardCurrentUser } from "@/hooks/use-dashboard-current-user";
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences";
 import { usePageMeta } from "@/hooks/use-page-meta";
+import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { getApiBase } from "@/lib/api-base";
 import { apiFetch } from "@/lib/api-client";
-import { isDashboardHrefAllowed, resolveAccessRole, resolveGrants } from "@/lib/access-control";
 import { formatDateTime } from "@/lib/date";
 import type { OperationalAlertsResponse } from "@/types/operational-alerts";
-import { ArrowDown, ArrowUp, SlidersHorizontal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
 
 type DashboardPost = {
   id: string;
@@ -1409,16 +1409,18 @@ const Dashboard = () => {
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, -1)}
                       disabled={!isSelected || index <= 0}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para cima`}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"
                       size="icon"
                       onClick={() => moveDraftWidget(widgetId, 1)}
                       disabled={!isSelected || index < 0 || index >= customDraftWidgets.length - 1}
+                      aria-label={`Mover widget ${DASHBOARD_WIDGET_LABELS[widgetId]} para baixo`}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
                     </DashboardActionButton>
                     <DashboardActionButton
                       type="button"


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label`s to the "Move Up" and "Move Down" icon-only buttons in the Dashboard customization modal.
🎯 **Why:** To improve accessibility for screen reader users, who previously would hear "button" without context.
♿ **Accessibility:** Added dynamic Portuguese descriptions mapping to the specific widget being moved (`Mover widget [Nome do Widget] para cima`), and added `aria-hidden="true"` to the inner SVG icons to prevent redundant announcements.

---
*PR created automatically by Jules for task [12047173989826015179](https://jules.google.com/task/12047173989826015179) started by @Gavuriiru*