### PR TITLE
🎨 Palette: [a11y] Add aria-labels to icon-only Delete buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## $(date +%Y-%m-%d) - Added ARIA labels to Settings Dashboard Trash Buttons
 **Learning:** Found several icon-only action buttons (e.g. Delete/Trash) in the dashboard settings layout missing `aria-label`s, indicating this might be a pattern across internal dashboard components where functionality is prioritized over a11y.
 **Action:** Always verify icon-only buttons (`DashboardActionButton` using Lucide icons) have appropriate `aria-label`s, especially in complex list/array configuration forms. Keep them in Portuguese to match the app's language context.
+## 2026-06-22 - Added dynamic aria-labels to icon-only Delete buttons
+**Learning:** Icon-only buttons (like `DashboardActionButton` wrapping `Trash2` icons) inside mapped  lists require distinct, dynamic `aria-label`s (e.g. `aria-label={`Remover fonte ${source.label}`}`) so screen reader users can differentiate between items in the list. Additionally, the nested SVG icons must use `aria-hidden="true"` to avoid redundant announcements.
+**Action:** When implementing or reviewing dashboard lists with action icons, explicitly check for both the presence of dynamic `aria-label`s on the button wrapper and `aria-hidden="true"` on the underlying SVG icon components.
+## 2024-05-14 - Added dynamic aria-labels to icon-only Delete buttons
+**Learning:** Icon-only buttons (like `DashboardActionButton` wrapping `Trash2` icons) inside mapped `.map()` lists require distinct, dynamic `aria-label`s (e.g. `aria-label={"Remover fonte ${source.label}"}`) so screen reader users can differentiate between items in the list. Additionally, the nested SVG icons must use `aria-hidden="true"` to avoid redundant announcements.
+**Action:** When implementing or reviewing dashboard lists with action icons, explicitly check for both the presence of dynamic `aria-label`s on the button wrapper and `aria-hidden="true"` on the underlying SVG icon components.

--- a/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsDownloadsTab.tsx
@@ -1,3 +1,5 @@
+import { Plus, Trash2 } from "lucide-react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import { Input } from "@/components/dashboard/dashboard-form-controls";
 import {
   dashboardStrongFocusFieldClassName,
@@ -5,14 +7,12 @@ import {
   dashboardStrongFocusTriggerClassName,
   dashboardStrongSurfaceHoverClassName,
 } from "@/components/dashboard/dashboard-page-tokens";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -184,6 +184,7 @@ export const DashboardSettingsDownloadsTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveSvgCardMobileRemoveButtonClass}
+                        aria-label={`Remover fonte ${source.label || index + 1}`}
                         onClick={() =>
                           setSettings((prev) => ({
                             ...prev,
@@ -194,7 +195,7 @@ export const DashboardSettingsDownloadsTab = () => {
                           }))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
@@ -202,6 +203,7 @@ export const DashboardSettingsDownloadsTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
+                    aria-label={`Remover fonte ${source.label || index + 1}`}
                     onClick={() =>
                       setSettings((prev) => ({
                         ...prev,
@@ -212,7 +214,7 @@ export const DashboardSettingsDownloadsTab = () => {
                       }))
                     }
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsSocialLinksTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Plus, Save, Trash2 } from "lucide-react";
 import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
 import ThemedSvgLogo from "@/components/ThemedSvgLogo";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
-import { Plus, Save, Trash2 } from "lucide-react";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -134,11 +134,12 @@ export const DashboardSettingsSocialLinksTab = () => {
                         type="button"
                         size="icon"
                         className={responsiveSvgCardMobileRemoveButtonClass}
+                        aria-label={`Remover rede ${link.label || index + 1}`}
                         onClick={() =>
                           setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))
                         }
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </DashboardActionButton>
                     </div>
                   </div>
@@ -146,9 +147,10 @@ export const DashboardSettingsSocialLinksTab = () => {
                     type="button"
                     size="icon"
                     className={responsiveSvgCardDesktopRemoveButtonClass}
+                    aria-label={`Remover rede ${link.label || index + 1}`}
                     onClick={() => setLinkTypes((prev) => prev.filter((_, idx) => idx !== index))}
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
                   </DashboardActionButton>
                 </div>
               );

--- a/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTeamTab.tsx
@@ -93,6 +93,7 @@ export const DashboardSettingsTeamTab = () => {
                   type="button"
                   size="icon"
                   className={responsiveCompactRowDeleteButtonClass}
+                  aria-label={`Remover função ${role.label || index + 1}`}
                   onClick={() =>
                     setSettings((prev) => ({
                       ...prev,
@@ -100,7 +101,7 @@ export const DashboardSettingsTeamTab = () => {
                     }))
                   }
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </DashboardActionButton>
               </div>
             ))}

--- a/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
+++ b/src/components/dashboard/settings/DashboardSettingsTranslationsTab.tsx
@@ -1,10 +1,10 @@
-import { Input } from "@/components/dashboard/dashboard-form-controls";
-import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
-import { Card, CardContent } from "@/components/ui/card";
-import { TabsContent } from "@/components/ui/tabs";
 import { Download, Plus, Save, Trash2 } from "lucide-react";
 import type { UIEvent } from "react";
 import { useState } from "react";
+import DashboardActionButton from "@/components/dashboard/DashboardActionButton";
+import { Input } from "@/components/dashboard/dashboard-form-controls";
+import { Card, CardContent } from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
 import { useDashboardSettingsContext } from "./dashboard-settings-context";
 import {
   dashboardSettingsCardClassName,
@@ -181,6 +181,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução da tag ${tag}`}
                             onClick={() =>
                               setTagTranslations((prev) => {
                                 const next = { ...prev };
@@ -189,7 +190,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -317,6 +318,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução do gênero ${genre}`}
                             onClick={() =>
                               setGenreTranslations((prev) => {
                                 const next = { ...prev };
@@ -325,7 +327,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>
@@ -448,6 +450,7 @@ export const DashboardSettingsTranslationsTab = () => {
                         <td className="px-4 py-3 text-right">
                           <DashboardActionButton
                             size="icon"
+                            aria-label={`Remover tradução da função ${role}`}
                             onClick={() =>
                               setStaffRoleTranslations((prev) => {
                                 const next = { ...prev };
@@ -456,7 +459,7 @@ export const DashboardSettingsTranslationsTab = () => {
                               })
                             }
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </DashboardActionButton>
                         </td>
                       </tr>


### PR DESCRIPTION
💡 **What**: Added dynamic `aria-label`s to multiple icon-only "Delete" buttons (`DashboardActionButton`s containing `Trash2` icons) across several Dashboard Settings tabs. I also added `aria-hidden="true"` to the child `Trash2` icons themselves.

🎯 **Why**: Icon-only buttons without `aria-label`s are opaque to screen reader users, making it impossible to know what the button does or which specific item it targets for deletion. Adding dynamic labels (e.g., "Remover tradução da tag Ação") allows users to confidently manage their dashboard settings. Adding `aria-hidden="true"` prevents screen readers from redundantly announcing the SVG structure.

📸 **Before/After**: Visually, the UI remains exactly the same. The change is exclusively perceptible via screen reader or DOM inspection.

♿ **Accessibility**: Significant improvement in screen reader usability. Screen readers will now announce "Remover rede Twitter, botão" instead of just "botão" when navigating settings lists.

---
*PR created automatically by Jules for task [8323149897340750488](https://jules.google.com/task/8323149897340750488) started by @Gavuriiru*