### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass in IPv6 parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,7 @@
 **Vulnerability:** Raw HTML strings were assigned to `innerHTML` sinks without sanitization within `src/lexical-playground/nodes/ImageNode.tsx` and `src/lexical-playground/hooks/useReport.ts`.
 **Learning:** Even within an encapsulated rich-text editor setup or helper hooks, directly passing HTML strings to `innerHTML` exposes an XSS risk if those strings can be populated with user content.
 **Prevention:** Always sanitize strings with `DOMPurify.sanitize` (using strict profiles like `{ USE_PROFILES: { html: true } }` where appropriate) before rendering them via `innerHTML` or `dangerouslySetInnerHTML`.
+## 2025-05-23 - [Prevent SSRF IPv6 Bracket Bypass]
+**Vulnerability:** The SSRF prevention logic in `isPrivateHost` did not strip IPv6 brackets `[]` from the hostname, allowing URLs like `http://[::1]/` to bypass the private IP blocklist because `net.isIP("[::1]")` returns 0.
+**Learning:** Node.js's `URL` parsing retains brackets for IPv6 hostnames (e.g. `[::1]`). Custom IP validation must explicitly strip these brackets before validating the IP against local/private ranges.
+**Prevention:** Always strip `[` and `]` characters from hostnames using `.replace(/^\[|\]$/g, "")` before using `net.isIP()` or matching against an IP blocklist.

--- a/server/lib/remote-image-import.js
+++ b/server/lib/remote-image-import.js
@@ -72,7 +72,8 @@ const isPrivateIpv6 = (value) => {
 const isPrivateHost = (host) => {
   const normalized = String(host || "")
     .trim()
-    .toLowerCase();
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
   if (!normalized) {
     return true;
   }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) blocklist bypass. Node.js `URL` parsing retains brackets for IPv6 hostnames (e.g., `[::1]`). The `isPrivateHost` blocklist used `net.isIP()`, which returns `0` (false) when given a bracketed IP address. This allowed attackers to bypass the local IP blocklist and make the server fetch internal assets by requesting URLs like `http://[::1]/`.
🎯 **Impact:** An attacker could exploit the remote image import endpoint to probe internal network services, access internal administration endpoints mapped to localhost, or leak sensitive metadata from the host machine.
🔧 **Fix:** Added a `.replace(/^\[|\]$/g, "")` step to the hostname normalization process within `isPrivateHost` (`server/lib/remote-image-import.js`). This strips the bracket syntax before executing the `net.isIP()` validation, ensuring IPv6 targets are correctly identified and blocked.
✅ **Verification:** Verified by code review and Biome linter check. Tested that `isPrivateHost` accurately filters `[::1]` as an internal/private host without erroring. Evaluated and confirmed the logic holds for all test cases.

---
*PR created automatically by Jules for task [13749694780641491780](https://jules.google.com/task/13749694780641491780) started by @Gavuriiru*