### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass for bracketed IPv6 addresses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,7 @@
 **Vulnerability:** Raw HTML strings were assigned to `innerHTML` sinks without sanitization within `src/lexical-playground/nodes/ImageNode.tsx` and `src/lexical-playground/hooks/useReport.ts`.
 **Learning:** Even within an encapsulated rich-text editor setup or helper hooks, directly passing HTML strings to `innerHTML` exposes an XSS risk if those strings can be populated with user content.
 **Prevention:** Always sanitize strings with `DOMPurify.sanitize` (using strict profiles like `{ USE_PROFILES: { html: true } }` where appropriate) before rendering them via `innerHTML` or `dangerouslySetInnerHTML`.
+## 2025-05-24 - [SSRF Bypass via IPv6 Brackets]
+**Vulnerability:** Server-Side Request Forgery (SSRF) bypass due to `net.isIP` failing to recognize IPv6 addresses enclosed in square brackets (e.g., `[::1]`). Node.js `URL` parsing retains the brackets in `url.hostname`, so `isPrivateHost("[::1]")` evaluated to false, allowing private IP targets.
+**Learning:** Checking hostnames directly from `URL.hostname` against `net.isIP()` can be bypassed if IPv6 brackets are present because `net.isIP("[::1]")` returns 0.
+**Prevention:** Always strip leading and trailing square brackets (`.replace(/^\[|\]$/g, '')`) from parsed hostnames before evaluating them with `net.isIP()` or custom IP parsing logic.

--- a/server/lib/remote-image-import.js
+++ b/server/lib/remote-image-import.js
@@ -72,7 +72,8 @@ const isPrivateIpv6 = (value) => {
 const isPrivateHost = (host) => {
   const normalized = String(host || "")
     .trim()
-    .toLowerCase();
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
   if (!normalized) {
     return true;
   }

--- a/src/server/remote-image-import.test.ts
+++ b/src/server/remote-image-import.test.ts
@@ -35,6 +35,18 @@ afterEach(() => {
 });
 
 describe("importRemoteImageFile", () => {
+  it("rejeita hostnames privados em IPv6 bracketed bypass", async () => {
+    const fetchMock = vi.fn();
+    const result = await importRemoteImageFile({
+      remoteUrl: "http://[::1]/imagem.png",
+      uploadsDir: createTempUploadsDir(),
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false ? result.error?.code : null).toBe("host_not_allowed");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("baixa imagem valida e salva em /uploads com metadados", async () => {
     const uploadsDir = createTempUploadsDir();
     const fetchMock = vi.fn(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Server-Side Request Forgery (SSRF) bypass due to `URL.hostname` retaining square brackets for IPv6 addresses (e.g., `[::1]`), causing `net.isIP` to return 0 and bypass the private host blocklist.
🎯 Impact: Attackers could provide bracketed IPv6 local addresses to fetch internal or loopback resources, bypassing the SSRF proxy protection on remote image imports.
🔧 Fix: Stripped leading and trailing brackets from the hostname before validating it with `net.isIP` in `server/lib/remote-image-import.js`.
✅ Verification: Added unit tests ensuring that `http://[::1]/imagem.png` is correctly blocked as a private host, which can be run with `pnpm test run src/server/remote-image-import.test.ts`.

---
*PR created automatically by Jules for task [4244472490833589843](https://jules.google.com/task/4244472490833589843) started by @Gavuriiru*